### PR TITLE
Converting polygons, linestrings to points

### DIFF
--- a/src/components/search/Index.vue
+++ b/src/components/search/Index.vue
@@ -211,10 +211,10 @@ const tabs = computed(() => {
 });
 
 const zoomToMatch = (match: any) => {
-  if (!match.id) return;
+  if (!match?.id) return;
 
-  if (props.addStroke && match.geom) {
-    mapLayers.zoomToFeatureCollection(match.geom, true);
+  if (match.geom) {
+    mapLayers.zoomToFeatureCollection(match.geom, !!props.addStroke);
   } else if (match.extent) {
     mapLayers.zoomToExtent(match.extent);
   } else if (match.x && match.y) {

--- a/src/routes/edit.vue
+++ b/src/routes/edit.vue
@@ -153,7 +153,12 @@ const selectSearch = (match: any) => {
   }
   if (!match?.geom) return;
 
-  mapDraw.value.setFeatures(match.geom, !!query.multi).edit();
+  mapDraw.value
+    .setFeatures(match.geom, {
+      append: !!query.multi,
+      types: drawTypes.value.map((i) => i.type),
+    })
+    .edit();
 };
 
 const toggleDrawType = (type: string) => {

--- a/src/utils/map/draw.ts
+++ b/src/utils/map/draw.ts
@@ -10,6 +10,7 @@ import { click } from 'ol/events/condition';
 import _ from 'lodash';
 import { GeometryType, getFeatures, parse } from 'geojsonjs';
 import { getLayerStyles } from '../layers';
+import { convertFeaturesToPoints } from './utils';
 
 type CallbackType = 'change' | 'select' | 'remove';
 
@@ -66,12 +67,23 @@ export class MapDraw extends Queues {
     return this;
   }
 
-  setFeatures(features: { [key: string]: any }, append: boolean = false) {
+  setFeatures(
+    features: { [key: string]: any },
+    options: {
+      append?: boolean;
+      types?: string[];
+    } = {},
+  ) {
     if (_.isEmpty(features)) return;
 
     try {
-      const data = new GeoJSON().readFeatures(features);
-      if (!append) {
+      let data = new GeoJSON().readFeatures(features);
+
+      if (options?.types?.length) {
+        data = convertFeaturesToPoints(data, options?.types || []);
+      }
+
+      if (!options?.append) {
         this.remove();
       }
       this._source.addFeatures(data);
@@ -100,7 +112,7 @@ export class MapDraw extends Queues {
       this._defaultColors.primary = primary;
       this._defaultColors.secondary = secondary;
     }
-    
+
     return this.setStyles({
       ...this._styles.opts,
       colors: {


### PR DESCRIPTION
Problem: when searching it returns polygons, line strings, points. However, if only point type is enabled we need to convert those results to points. 

Implementation is just a first step but it will work.

Later on we need to implement different convertions to points, line strings, polygons, etc. And check by `multi` property as well. 