### PR TITLE
Add legend title as props

### DIFF
--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="text-xs">
-    <p class="text-sm font-semibold mb-3">Legenda</p>
+    <p class="text-sm font-semibold mb-3">{{ title }}</p>
     <UiMapLegendItems v-if="legendData.length" :items="legendData" />
     <UiIcon v-else name="spinner" />
   </div>
@@ -14,6 +14,11 @@ const props = defineProps({
     type: String,
     default: '',
     required: true,
+  },
+  title: {
+    type: String,
+    default: 'Legenda',
+    required: false,
   },
 });
 

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -27,7 +27,7 @@
             { type: 'upė', weight: 2 },
           ]"
         />
-        <UiMapLegend v-if="filtersStore.isActive('legend')" :layer="uetkService.id" :title="'Sutartiniai ženklai'"/>
+        <UiMapLegend v-if="filtersStore.isActive('legend')" :layer="uetkService.id" title="Sutartiniai ženklai"/>
       </template>
       <template #sidebar>
         <UiSidebarFeatures

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -27,7 +27,7 @@
             { type: 'upė', weight: 2 },
           ]"
         />
-        <UiMapLegend v-if="filtersStore.isActive('legend')" :layer="uetkService.id" />
+        <UiMapLegend v-if="filtersStore.isActive('legend')" :layer="uetkService.id" :title="'Sutartiniai ženklai'"/>
       </template>
       <template #sidebar>
         <UiSidebarFeatures


### PR DESCRIPTION
Add legend title as props to allow customize the title. Default value for title will remain 'Legenda' but you can set now your own title with :title props.
![image](https://github.com/AplinkosMinisterija/biip-maps-web/assets/1758436/b303566c-7015-46c7-9709-f34f7a56ab42)
