### PR TITLE
Control feature sidebar showing with url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ https://maps.biip.lt/alis/fishing
 | -------------- | ------------------------------------- | --------- | ------- |
 | `cadastral_id` | Filters and highlighs by cadastral ID | `Filter`  | -       |
 | `show_search`  | Enables search                        | `Boolean` | `false` |
+| `preview`      | Enables feature sidebar               | `Boolean` | `false` |
 
 ### Events
 

--- a/src/routes/alis/fishing.vue
+++ b/src/routes/alis/fishing.vue
@@ -77,7 +77,7 @@ const toggleLayers = [
 
 const $route = useRoute();
 
-const query = parseRouteParams($route.query, ['cadastral_id', 'show_search', 'info_window_enabled']);
+const query = parseRouteParams($route.query, ['cadastral_id', 'show_search', 'preview']);
 if (query.cadastral_id) {
   const uetkServiceFilters = mapLayers.filters(uetkService.id);
 
@@ -114,7 +114,7 @@ mapLayers
   .add(uetkService.id)
   .click(async ({ coordinate }: any) => {
     mapLayers.getFeatureInfo(uetkService.id, coordinate, ({ geometries, properties }: any) => {
-      if (query.info_window_enabled) {
+      if (query.preview) {
         mapLayers.highlightFeatures(geometries);
         selectedFeatures.value = properties;
       }

--- a/src/routes/alis/fishing.vue
+++ b/src/routes/alis/fishing.vue
@@ -77,7 +77,7 @@ const toggleLayers = [
 
 const $route = useRoute();
 
-const query = parseRouteParams($route.query, ['cadastral_id', 'show_search']);
+const query = parseRouteParams($route.query, ['cadastral_id', 'show_search', 'info_window_enabled']);
 if (query.cadastral_id) {
   const uetkServiceFilters = mapLayers.filters(uetkService.id);
 
@@ -114,8 +114,10 @@ mapLayers
   .add(uetkService.id)
   .click(async ({ coordinate }: any) => {
     mapLayers.getFeatureInfo(uetkService.id, coordinate, ({ geometries, properties }: any) => {
-      mapLayers.highlightFeatures(geometries);
-      selectedFeatures.value = properties;
+      if (query.info_window_enabled) {
+        mapLayers.highlightFeatures(geometries);
+        selectedFeatures.value = properties;
+      }
       postMessage('click', properties);
     });
   })


### PR DESCRIPTION
Request from ALIS - control feature sidebar with url parameter. Click event is still needed for postMessage.

I added url parameter ```info_window_enabled``` that controls if feature sidebar will be showed on click. By default feature sidebar will not be shown. 