### PR TITLE
Mobile padding

### DIFF
--- a/src/components/ui/map/Index.vue
+++ b/src/components/ui/map/Index.vue
@@ -8,6 +8,7 @@
         showScaleLine: showScaleLine,
         showCoordinates: showCoordinates && !isPreview,
         projection: projection,
+        constrainResolution: constrainResolution
       }"
     />
     <div
@@ -158,6 +159,10 @@ defineProps({
   projection: {
     type: String,
     default: '',
+  },
+  constrainResolution: {
+    type: Boolean,
+    default: true,
   },
 });
 

--- a/src/components/ui/map/Index.vue
+++ b/src/components/ui/map/Index.vue
@@ -4,11 +4,11 @@
       v-map="{
         showZoom: showZoom && !isPreview,
         showAttribution: showAttribution && (!isPreview || attributionOptions),
-        attributionOptions: attributionOptions,
-        showScaleLine: showScaleLine,
+        attributionOptions,
+        showScaleLine,
         showCoordinates: showCoordinates && !isPreview,
-        projection: projection,
-        constrainResolution: constrainResolution
+        projection,
+        constrainResolution,
       }"
     />
     <div

--- a/src/routes/hunting/tracks.vue
+++ b/src/routes/hunting/tracks.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <UiMap :show-scale-line="true" :show-coordinates="true" />
+    <UiMap :show-scale-line="true" :show-coordinates="true" :constrain-resolution="false"/>
   </div>
 </template>
 <script setup lang="ts">

--- a/src/routes/medziokle/index.vue
+++ b/src/routes/medziokle/index.vue
@@ -1,12 +1,16 @@
 <template>
   <div>
-    <UiMap :show-scale-line="true" :mark-center="!!query.draw" />
+    <UiMap
+      :show-scale-line="true"
+      :mark-center="!!query.draw"
+      :constrain-resolution="false"
+    />
   </div>
 </template>
 <script setup lang="ts">
-import { computed, inject } from 'vue';
-import { useRoute } from 'vue-router';
-import { parse, GeometryType } from 'geojsonjs';
+import { computed, inject } from "vue";
+import { useRoute } from "vue-router";
+import { parse, GeometryType } from "geojsonjs";
 import {
   geoportalTopo,
   geoportalOrto,
@@ -14,23 +18,23 @@ import {
   huntingService,
   parseRouteParams,
   convertCoordinatesToProjection,
-} from '@/utils';
+} from "@/utils";
 
-const mapLayers: any = inject('mapLayers');
-const events: any = inject('events');
-const postMessage: any = inject('postMessage');
+const mapLayers: any = inject("mapLayers");
+const events: any = inject("events");
+const postMessage: any = inject("postMessage");
 const $route = useRoute();
 
-const query = parseRouteParams($route.query, ['mpvId', 'draw', 'zoom', 'points']);
+const query = parseRouteParams($route.query, ["mpvId", "draw", "zoom", "points"]);
 const huntingServiceFilters = mapLayers.filters(huntingService.id);
 
 if (query.mpvId) {
-  huntingServiceFilters.on('mpv_info_geom').set('mpv_id', query.mpvId);
+  huntingServiceFilters.on("mpv_info_geom").set("mpv_id", query.mpvId);
 }
 
 const colors: any = {
-  current: '#004650',
-  other: '#A5B9C0',
+  current: "#004650",
+  other: "#A5B9C0",
 };
 
 function zoomToCoordinate(data: any) {
@@ -64,22 +68,22 @@ function parsePoints(data: any[]) {
         color: colors[item.type] || colors.current,
         ...item,
       },
-    })),
+    }))
   );
 
   mapDraw.value.setFeatures(featureCollection).edit();
 }
 
-events.on('points', parsePoints).on('zoom', zoomToCoordinate);
+events.on("points", parsePoints).on("zoom", zoomToCoordinate);
 
 mapDraw.value
   .enableSelect()
   .enablePan(!!query.draw)
-  .on('select', ({ feature }: any) => {
-    postMessage('selected', feature);
+  .on("select", ({ feature }: any) => {
+    postMessage("selected", feature);
   })
-  .on('change', ({ features }: any) => {
-    postMessage('data', features);
+  .on("change", ({ features }: any) => {
+    postMessage("data", features);
   });
 
 if (query.points) {

--- a/src/utils/map/index.ts
+++ b/src/utils/map/index.ts
@@ -23,6 +23,7 @@ export function createMap(
     centerView?: number[];
     zoomView?: number;
     projection?: string;
+    constrainResolution?: boolean;
   },
 ) {
   const proj = get(options?.projection || projection);
@@ -33,7 +34,7 @@ export function createMap(
       center: options?.centerView || [495074.61, 6116454.53],
       projection: proj as Projection,
       zoom: options?.zoomView || 9,
-      constrainResolution: true,
+      constrainResolution: options?.constrainResolution,
     }),
     controls: defaults({
       attribution: !!options?.showAttribution,

--- a/src/utils/map/layers.ts
+++ b/src/utils/map/layers.ts
@@ -623,6 +623,16 @@ export class MapLayers extends Queues {
 
   zoomToExtent(extent: any, padding: number = 50) {
     if (!extent || !this.map) return;
+
+    const width = this.map.getViewport().clientWidth;
+
+    if (padding === 50) {
+      if (width < 480) padding = 10;
+      else if (width < 640) padding = 15;
+      else if (width < 768) padding = 25;
+      else if (width < 1280) padding = 40;
+    }
+
     this.map.getView().fit(extent, {
       padding: [padding, padding, padding, padding],
       maxZoom: this._getZoomLevel(),


### PR DESCRIPTION
On smaller screens gap (padding) of 50 is too big. So for that padding now depends on screen size

- [x] Disable constrain resolution for specific paths
- [x] Dynamic zoom padding by map viewport width

Before:
<img width="384" alt="image" src="https://github.com/AplinkosMinisterija/biip-maps-web/assets/25932455/4579039c-c6fd-4fb7-b8a6-558f009ced88">

After:
<img width="377" alt="image" src="https://github.com/AplinkosMinisterija/biip-maps-web/assets/25932455/83f080d7-d910-4fb6-b070-5b1412428671">
