### PR TITLE
Adding buffer options + displaying them in map

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ https://maps.biip.lt/edit
 
 ### Parameters
 
-| Name      | Desciption                  | Type       | Default                        |
-| --------- | --------------------------- | ---------- | ------------------------------ |
-| `multi`   | Enables multi geometry      | `Boolean`  | false                          |
-| `buffer`  | Enables buffers to geometry | `Boolean`  | false                          |
-| `preview` | Disables editing            | `Boolean`  | false                          |
-| `types`   | Enables specific draw types | `String[]` | `['point', 'polygon', 'line']` |
+| Name      | Desciption                  | Type                  | Default                                                                     |
+| --------- | --------------------------- | --------------------- | --------------------------------------------------------------------------- |
+| `multi`   | Enables multi geometry      | `Boolean`             | false                                                                       |
+| `buffer`  | Enables buffers to geometry | `Boolean` \| `String` | false. Possible - `xs` (default if boolean), `sm`, `md`, `lg`, `xl` values. |
+| `preview` | Disables editing            | `Boolean`             | false                                                                       |
+| `types`   | Enables specific draw types | `String[]`            | `['point', 'polygon', 'line']`                                              |
 
 ### Events
 

--- a/src/routes/edit.vue
+++ b/src/routes/edit.vue
@@ -137,14 +137,15 @@ const hasDrawType = (type: string) => {
 const filtersStore = useFiltersStore();
 
 const bufferSizes: any = {
-  default: { min: 1, max: 5, step: 1 },
+  xs: { min: 1, max: 5, step: 1 },
+  sm: { min: 10, max: 100, step: 10 },
   md: { min: 100, max: 1000, step: 100 },
   lg: { min: 500, max: 5000, step: 500 },
   xl: { min: 1000, max: 10000, step: 1000 },
 };
 
 const bufferSizeKey =
-  query.buffer && bufferSizes[query.buffer] ? query.buffer : "default";
+  query.buffer && bufferSizes[query.buffer] ? query.buffer : "xs";
 
 const bufferSizeLabel = computed(() => {
   const text = `Buferio dydis`;

--- a/src/utils/layers/vector.ts
+++ b/src/utils/layers/vector.ts
@@ -87,9 +87,13 @@ export function getLayerStyles(opts: {
         const circle = styleClone.getImage() as Circle;
         const lightColor = styleClone.getFill().getColor()?.toString();
 
+        const width = (bufferSize * 2) / resolution;
+
+        if (width > 4000) return styleClone;
+
         const bufferStroke = new Stroke({
           color: lightColor,
-          width: (bufferSize * 2) / resolution,
+          width,
         });
 
         circle.setStroke(bufferStroke);
@@ -136,6 +140,7 @@ export const fixedHighlightLayer = {
 export const drawLayer = {
   id: 'drawLayer',
   layer: new VectorLayer({
+    renderBuffer: 2000,
     style: function (feature) {
       const color = feature.get('color');
       const radius = feature.get('radius') || 3;

--- a/src/utils/layers/vector.ts
+++ b/src/utils/layers/vector.ts
@@ -40,14 +40,9 @@ export function getLayerStyles(opts: {
     const stroke = new Stroke({ color: brightColor, width });
     const fill = new Fill({ color: lightColor });
 
-    const bufferStroke = options?.bufferWidth
-      ? new Stroke({ color: lightColor, width: options?.bufferWidth })
-      : undefined;
-
     let image: any = new Circle({
       radius: width * 2,
       fill: new Fill({ color: brightColor }),
-      stroke: bufferStroke,
     });
 
     if (icon) {

--- a/src/utils/layers/vector.ts
+++ b/src/utils/layers/vector.ts
@@ -30,7 +30,6 @@ export function getLayerStyles(opts: {
     options?: {
       align?: 'top';
       width?: number;
-      bufferWidth: number;
     },
   ) {
     const brightColor = `${color}bb`;

--- a/src/utils/map/draw.ts
+++ b/src/utils/map/draw.ts
@@ -25,6 +25,7 @@ export class MapDraw extends Queues {
   };
   private _enabledContinuousDraw: boolean = false;
   private _enabledBufferSize: boolean = false;
+  private _defaultBufferSizeValue: number = 1;
   private _source = new VectorSource({
     wrapX: false,
     format: new GeoJSON({
@@ -148,8 +149,9 @@ export class MapDraw extends Queues {
     return this;
   }
 
-  enableBufferSize(value: boolean = false) {
+  enableBufferSize(value: boolean = false, defaultValue: number = 1) {
     this._enabledBufferSize = !!value;
+    this._defaultBufferSizeValue = defaultValue;
     return this;
   }
 
@@ -361,7 +363,8 @@ export class MapDraw extends Queues {
       if (!feature) return;
 
       if (this._enabledBufferSize) {
-        const bufferSize = this.getProperties(feature, 'bufferSize') || 1;
+        const bufferSize =
+          this.getProperties(feature, 'bufferSize') || this._defaultBufferSizeValue;
         this.setProperties(feature, { bufferSize });
       }
 


### PR DESCRIPTION
<img width="1511" alt="image" src="https://github.com/AplinkosMinisterija/biip-maps-web/assets/25932455/a39205a1-a040-49f0-bedb-9c481be3ae9c">

From now on:
- You can pass `buffer=xl`, `buffer=lg` params. Default option is `xs` meaning 1-5 meters radius. It's backward compatible - all previous versions with `buffer=1` or `buffer=true` by default gets `xs` buffer size.
- It displays radius on the map dynamically
- Dynamic change in label between `m` and `km`