### PR TITLE
Fix - enable buffer size (default) when search from input

### DIFF
--- a/src/utils/map/draw.ts
+++ b/src/utils/map/draw.ts
@@ -87,6 +87,15 @@ export class MapDraw extends Queues {
       if (!options?.append) {
         this.remove();
       }
+
+      if (this._enabledBufferSize) {
+        data?.forEach((feature) => {
+          const bufferSize =
+            this.getProperties(feature, 'bufferSize') || this._defaultBufferSizeValue;
+          this.setProperties(feature, { bufferSize });
+        });
+      }
+
       this._source.addFeatures(data);
       this._triggerCallbacks('change');
     } catch (err) {


### PR DESCRIPTION
Right now if buffer size is enabled & entered from input - no buffer size is applied. It causes some issues in `rusys` application. 

After this change if buffer size is enabled & entered from search input - auto (default) buffer size is applied