### PR TITLE
[Edit] Zoom by address (by geoportal search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ https://maps.biip.lt/animals/draw
 
 **Listens:**
 
-| Name   | Desciption                        | Type               |
-| ------ | --------------------------------- | ------------------ |
-| `geom` | Draws provided feature collection | Feature collection |
+| Name      | Desciption                             | Type                                    |
+| --------- | -------------------------------------- | --------------------------------------- |
+| `geom`    | Draws provided feature collection      | Feature collection                      |
+| `address` | Zooms to provided address + adds point | String (e.g. `Gedimino pr. 1, Vilnius`) |
 
 **Sends:**
 

--- a/src/routes/edit.vue
+++ b/src/routes/edit.vue
@@ -267,7 +267,7 @@ events.on("geom", (data: any) => {
 events.on("address", (data: any) => {
   const address = data.address || data;
 
-  // now supports only street + house number + city (e.g. Gedimino pr. 12, Vilnius)
+  // now supports only street + building number + city (e.g. Gedimino pr. 12, Vilnius)
   // TODO: update this part to support every address (including municipality, etc)
   searchGeoportal(address, [{ type: "adresas", weight: 2 }], {
     fields: ["VARDAS^5"],

--- a/src/utils/requests/search.ts
+++ b/src/utils/requests/search.ts
@@ -54,7 +54,7 @@ export function searchGeoportal(
         multi_match: {
           query: value,
           type: 'most_fields',
-          fields: [
+          fields: options?.fields || [
             'VARDAS^5',
             'VARDAS.folded^5',
             'VARDAS.shingle^5',
@@ -109,7 +109,7 @@ export function searchGeoportal(
         }
         return {
           id: item._id,
-          x: source.LOCATION,
+          x: source.LOCATIONX,
           y: source.LOCATIONY,
           name: source.VARDAS,
           description: source.DESCRIPTIO,


### PR DESCRIPTION
Only supports street, building number & city (e.g. `Gedimino pr. 1, Vilnius`). Cannot support `Gedimino pr. 1, Vilnius, Vilniaus m. sav.` - will fix it later on. Maybe check in other registries, etc.