### PR TITLE
Add szns parcels service configuration and use logic

### DIFF
--- a/src/components/features/accordion/Szns.vue
+++ b/src/components/features/accordion/Szns.vue
@@ -3,8 +3,8 @@
     <UiAccordionItem
       v-for="feature in features"
       :key="feature.featureId"
-      :title="feature['3. Paviršinio vandens telkinio pavadinimas'] || feature['1. Pavadinimas']"
-      :subtitle="feature['1. Specialioji sąlyga'] || feature['3. Kategorija']"
+      :title="getFeatureTitle(feature)"
+      :subtitle="getFeatureSubtitle(feature)"
     >
       <UiTable class="text-xs">
         <UiTableRow v-for="item in getSorted(feature)" :key="item.id">
@@ -12,7 +12,9 @@
             {{ item.name }}
           </UiTableCell>
           <UiTableCell class="w-1/2">
-            {{ item.value }}
+            <div>
+              {{ formatValue(item) }}
+            </div>
           </UiTableCell>
         </UiTableRow>
       </UiTable>
@@ -38,6 +40,10 @@ defineProps({
 });
 
 const urlAttribute = '6. Papildoma informacija';
+const valueToRoundAttributes = [
+  'Rengiamų pakrantės apsaugos juostų dydis (ha)',
+  'Rengiamų paviršinių vandens telkinių apsaugos zonų dydis (ha)',
+];
 
 const getSorted = (properties: any) => {
   return Object.entries(properties)
@@ -51,5 +57,27 @@ const getSorted = (properties: any) => {
       return a.id.localeCompare(b.id);
     })
     .filter((item: any) => !['featureId', '_layerTitle', urlAttribute].includes(item.name));
+};
+
+const getFeatureTitle = (feature: any) => {
+  return (
+    feature['3. Paviršinio vandens telkinio pavadinimas'] ||
+    feature['1. Pavadinimas'] ||
+    feature['Unikalus ID']
+  );
+};
+
+const getFeatureSubtitle = (feature: any) => {
+  return feature['1. Specialioji sąlyga'] || feature['3. Kategorija'] || feature['Kadastro Nr.'];
+};
+
+const formatValue = (item: any) => {
+  if (valueToRoundAttributes.includes(item.name)) {
+    if (item.value == 0) {
+      return 'Teritorija nenustatyta';
+    }
+    return Number(item.value).toFixed(3);
+  }
+  return item.value;
 };
 </script>

--- a/src/routes/szns/uetk.vue
+++ b/src/routes/szns/uetk.vue
@@ -45,7 +45,7 @@ import {
   geoportalTopoGray,
   uetkService,
   sznsUetkService,
-  inspireParcelService,
+  sznsUetkParcelsService,
   administrativeBoundariesLabelsService,
   geoportalHybrid,
   geoportalGrpk,
@@ -73,8 +73,8 @@ function onSearch(search: string) {
 
 const toggleLayers = [
   sznsUetkService,
+  sznsUetkParcelsService,
   uetkService,
-  inspireParcelService,
   administrativeBoundariesLabelsService,
   geoportalGrpk,
 ];
@@ -85,9 +85,9 @@ mapLayers
   .addBaseLayer(geoportalOrto.id)
   .add(geoportalGrpk.id, { isHidden: true })
   .add(administrativeBoundariesLabelsService.id, { isHidden: true })
-  .add(inspireParcelService.id)
   .add(uetkService.id, { isHidden: true })
   .add(sznsUetkService.id)
+  .add(sznsUetkParcelsService.id)
   .click(async ({ coordinate }: any) => {
     selectedFeatures.value = [];
     selectedGeometries.value = [];
@@ -102,11 +102,19 @@ mapLayers
       mapLayers.highlightFeatures(selectedGeometries.value);
       selectedFeatures.value = [...selectedFeatures.value, ...properties];
     });
+    mapLayers.getFeatureInfo(
+      sznsUetkParcelsService.id,
+      coordinate,
+      ({ geometries, properties }: any) => {
+        selectedGeometries.value = [...selectedGeometries.value, ...geometries];
+        mapLayers.highlightFeatures(selectedGeometries.value);
+        selectedFeatures.value = [...selectedFeatures.value, ...properties];
+      },
+    );
   });
 
 mapLayers.waitForLoaded.then(() => {
   filtersStore.toggle('layers');
-  mapLayers.setOpacity(inspireParcelService.id, 0.8);
 });
 
 if (query.cadastralId) {

--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -165,6 +165,17 @@ export const sznsUetkService = {
   ),
 };
 
+export const sznsUetkParcelsService = {
+  id: 'sznsUetkParcelsService',
+  title: 'Vandens juostų ir zonų statistika žemės sklypams',
+  description: [aaaCopyright, biipCopyright],
+  layer: getWMSImageLayer(
+    `${qgisServerUrl}/uetk_szns_parcels`,
+    'sklypai,seniunijos,savivaldybes,apskritys',
+    `${aaaCopyright} ${biipCopyright}`,
+  ),
+};
+
 export const stvkService = {
   id: 'stvkService',
   description: vsttCopyright,
@@ -267,7 +278,7 @@ export const rusysGridService = {
       color: 'rgba(0,70,80,0.8)',
       width: 1,
     },
-    dataProjection: projection
+    dataProjection: projection,
   }),
 };
 


### PR DESCRIPTION
Add new service configuration for SZNS map view:
- Add WMS service configuration and use logic like feature click, etc.
- Removing unused service from view.

Refactor template logic into utility functions for SZNS accordion component:
- Extract value formatting logic into `formatValue()` function.
- Extract feature title/subtitle logic into `getFeatureTitle()` and `getFeatureSubtitle()` functions.
- Improve template readability by removing complex inline conditionals.