### PR TITLE
Add map export functionality with PNG download option

### DIFF
--- a/src/composables/useMapExport.ts
+++ b/src/composables/useMapExport.ts
@@ -1,0 +1,52 @@
+export const useMapExport = () => {
+  const exportMapToPNG = (map: any, filename?: string): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      if (!map) {
+        reject(new Error('Map instance is required'));
+        return;
+      }
+
+      map.once('rendercomplete', () => {
+        try {
+          const mapCanvas = document.createElement('canvas');
+          const size = map.getSize();
+          mapCanvas.width = size[0];
+          mapCanvas.height = size[1];
+          const mapContext = mapCanvas.getContext('2d');
+
+          if (!mapContext) {
+            reject(new Error('Could not get canvas context'));
+            return;
+          }
+
+          document.querySelectorAll('.ol-layer canvas, canvas.ol-layer').forEach((canvas) => {
+            const canvasElement = canvas as HTMLCanvasElement;
+            if (canvasElement.width > 0) {
+              mapContext.drawImage(canvasElement, 0, 0);
+            }
+          });
+
+          const link = document.createElement('a');
+
+          const timestamp = new Date().toISOString().slice(0, 10);
+
+          const finalFilename = filename
+            ? `${filename}_${timestamp}.png`
+            : `zemelapis_${timestamp}.png`;
+
+          link.download = finalFilename;
+          link.href = mapCanvas.toDataURL();
+          link.click();
+
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      map.renderSync();
+    });
+  };
+
+  return { exportMapToPNG };
+};

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -14,6 +14,7 @@
         <UiButtonIcon icon="layers" @click="filtersStore.toggle('layers')" />
         <UiButtonIcon icon="legend" @click="filtersStore.toggle('legend')" />
         <UiMapMeasure />
+        <UiButtonIcon icon="download" @click="handleExportMap()" title="Atsisiųsti žemėlapį" />
       </template>
       <template v-if="filtersStore.active" #filtersContent>
         <UiMapLayerToggle v-if="filtersStore.isActive('layers')" :layers="toggleLayers" />
@@ -47,6 +48,7 @@
 </template>
 <script setup lang="ts">
 import { useFiltersStore } from '@/stores/filters';
+import { useMapExport } from '@/composables/useMapExport';
 import {
   administrativeBoundariesLabelsService,
   gamtotvarkaStvkService,
@@ -70,10 +72,12 @@ import { inject, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 const filtersStore = useFiltersStore();
+const { exportMapToPNG } = useMapExport();
 
 const mapLayers: any = inject('mapLayers');
 const postMessage: any = inject('postMessage');
 const events: any = inject('events');
+const eventBus: any = inject('eventBus');
 
 const selectedFeatures = ref([] as any[]);
 const $route = useRoute();
@@ -169,6 +173,22 @@ if (query.cadastralId) {
 events.on('filter', async ({ cadastralId }: any) => {
   await filterByCadastralId(cadastralId);
 });
+
+const handleExportMap = async () => {
+  try {
+    await exportMapToPNG(mapLayers.map, 'uetk_zemelapis');
+    eventBus?.emit('uiToast', {
+      type: 'success',
+      title: 'Žemėlapio paveikslėlis sugeneruotas',
+    });
+  } catch (error) {
+    eventBus?.emit('uiToast', {
+      type: 'danger',
+      title: 'Nepavyko išsaugoti žemėlapio paveikslėlio',
+      description: 'Pabandykite perkrauti naršyklės langą ir bandyti dar kartą.',
+    });
+  }
+};
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
Adds ability to export current map view as PNG image with download button.

## Changes
- **New**: `composables/useMapExport.ts` - Composable for map export logic

## Implementation
- Composites all visible map layer canvases into single PNG
- Uses OpenLayers `rendercomplete` event for timing
- Returns Promise for async error handling
- Auto-generates filename with timestamp: `zemelapis_2025-11-13.png`
- Supports custom filenames: `exportMapToPNG(map, 'custom_name')`

## Use Details
```typescript
// Composable pattern
const { exportMapToPNG } = useMapExport();

// Component usage
await exportMapToPNG(mapLayers.map, 'optional_filename');
```

- Canvas compositing handles multi-layer maps
- Timestamp format: `YYYY-MM-DD`
- Error handling with try/catch in component

## Example of png
<img width="1291" height="911" alt="szns_zemelapis_2025-11-13 (1)" src="https://github.com/user-attachments/assets/2319ba02-af97-4fb9-a116-841bfedeaafb" />
