### PR TITLE
Turn off parcel layer by default

### DIFF
--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -238,7 +238,7 @@ mapLayers
   .add(administrativeBoundariesLabelsService.id, { isHidden: true })
   .add(gamtotvarkaStvkService.id, { isHidden: true })
   .add(rcSzns.id, { isHidden: true })
-  .add(sznsUetkParcelsService.id)
+  .add(sznsUetkParcelsService.id, { isHidden: true })
   .add(uetkService.id)
   .click(async ({ coordinate }: any) => {
     selectedFeatures.value = [];


### PR DESCRIPTION
Set parcel layer to be hidden by default in UETK map view.