### PR TITLE
feat: add administrative boundaries layer to the edit route

### DIFF
--- a/src/routes/medziokle/edit.vue
+++ b/src/routes/medziokle/edit.vue
@@ -67,6 +67,7 @@ import Search from '@/components/search/Index.vue';
 import { useFiltersStore } from '@/stores/filters';
 import type { Buffer } from '@/types';
 import {
+  administrativeBoundariesLabelsService,
   convertFeatureCollectionProjection,
   geoportalForests,
   geoportalGrpk,
@@ -123,6 +124,7 @@ const toggleLayers = [
   uetkService,
   stvkService,
   municipalitiesService,
+  administrativeBoundariesLabelsService,
   geoportalGrpk,
   geoportalForests,
   geoportalOrto2018,
@@ -220,6 +222,7 @@ mapLayers
   .add(uetkService.id, { isHidden: true })
   .add(stvkService.id, { isHidden: true })
   .add(municipalitiesService.id, { isHidden: true })
+  .add(administrativeBoundariesLabelsService.id, { isHidden: true })
   .add(geoportalGrpk.id, { isHidden: true })
   .add(geoportalForests.id, { isHidden: true })
   .add(geoportalOrto2018.id, { isHidden: true })


### PR DESCRIPTION
Pridedami "Administracinės ribos" sluoksniai į /medziokle/edit maršrutą 
  — ta pati grupė, kuri jau naudojama UETK puslapyje                      
  (administrativeBoundariesLabelsService su sub-sluoksniais: Gyvenamosios 
  vietovės, Seniūnijos, Savivaldybės, Apskritys).
                                                                          
  Changes                                                         

  - src/routes/medziokle/edit.vue:
    - Pridėtas administrativeBoundariesLabelsService importas iš @/utils
    - Įtrauktas į toggleLayers sąrašą (kad būtų matomas sluoksnių
  perjungiklyje)
    - Registruojamas su mapLayers.add(..., { isHidden: true }) — pagal
  nutylėjimą paslėptas

  Test plan

  - Atidaryti /medziokle/edit?types[]=point&types[]=polygon
  - Atidaryti sluoksnių perjungiklį (layers icon) — patikrinti, ar matosi
  "Administracinės ribos" grupė su 4 sub-sluoksniais
  - Įjungti kiekvieną sub-sluoksnį (Savivaldybės, Apskritys, Seniūnijos,
  Gyvenamosios vietovės) ir patikrinti, ar etiketės atsiranda žemėlapyje
  - Patikrinti, kad esami sluoksniai (medžioklės plotai, UETK, STVK ir
  kt.) ir piešimo funkcionalumas (point/polygon) veikia kaip anksčiau