### PR TITLE
Issue #4: render UETK extract legend below map, visible-only

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,10 +48,32 @@ $router.isReady().then(() => {
   }
 });
 
+const waitForLegend = (timeoutMs = 5000) =>
+  new Promise<void>((resolve) => {
+    if (typeof document === "undefined") return resolve();
+    if (document.body.dataset.legendReady !== "false") return resolve();
+
+    const observer = new MutationObserver(() => {
+      if (document.body.dataset.legendReady === "true") {
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-legend-ready"],
+    });
+    setTimeout(() => {
+      observer.disconnect();
+      resolve();
+    }, timeoutMs);
+  });
+
 watch(
   isLoaded,
-  (value) => {
+  async (value) => {
     if (!value || !$route?.query?.screenshot) return;
+    await waitForLegend();
     canvasToImage();
   },
   { immediate: true }

--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -20,6 +20,10 @@ const props = defineProps({
     default: 'Legenda',
     required: false,
   },
+  visibleOnly: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const mapLayers: any = inject('mapLayers');
@@ -27,8 +31,10 @@ const mapLayers: any = inject('mapLayers');
 const legendData = ref([] as any);
 
 if (props.layer) {
-  mapLayers.getLegendData(props.layer)?.then((data: any) => {
-    legendData.value = data || [];
-  });
+  mapLayers
+    .getLegendData(props.layer, { visibleOnly: props.visibleOnly })
+    ?.then((data: any) => {
+      legendData.value = data || [];
+    });
 }
 </script>

--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text-xs">
     <p class="text-sm font-semibold mb-3">{{ title }}</p>
-    <UiMapLegendItems v-if="legendData.length" :items="legendData" />
+    <UiMapLegendItems v-if="legendData.length" :items="legendData" :inline="inline" />
     <UiIcon v-else name="spinner" />
   </div>
 </template>
@@ -21,6 +21,10 @@ const props = defineProps({
     required: false,
   },
   visibleOnly: {
+    type: Boolean,
+    default: false,
+  },
+  inline: {
     type: Boolean,
     default: false,
   },

--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts" setup>
-import { inject, ref } from 'vue';
+import { inject, onUnmounted, ref } from 'vue';
 
 const props = defineProps({
   layer: {
@@ -30,11 +30,30 @@ const mapLayers: any = inject('mapLayers');
 
 const legendData = ref([] as any);
 
+const setReadyFlag = (value: 'true' | 'false') => {
+  if (typeof document === 'undefined') return;
+  document.body.dataset.legendReady = value;
+};
+
 if (props.layer) {
-  mapLayers
-    .getLegendData(props.layer, { visibleOnly: props.visibleOnly })
-    ?.then((data: any) => {
-      legendData.value = data || [];
-    });
+  setReadyFlag('false');
+  const result = mapLayers.getLegendData(props.layer, {
+    visibleOnly: props.visibleOnly,
+  });
+  if (result && typeof result.then === 'function') {
+    result
+      .then((data: any) => {
+        legendData.value = data || [];
+      })
+      .finally(() => setReadyFlag('true'));
+  } else {
+    setReadyFlag('true');
+  }
 }
+
+onUnmounted(() => {
+  if (typeof document !== 'undefined') {
+    delete document.body.dataset.legendReady;
+  }
+});
 </script>

--- a/src/components/ui/map/legend/Item.vue
+++ b/src/components/ui/map/legend/Item.vue
@@ -1,11 +1,14 @@
 <template>
-  <div>
+  <div :class="inline ? 'flex flex-row flex-wrap gap-x-3 gap-y-1 items-center' : ''">
     <div class="flex items-center gap-2">
       <img v-if="icon" :src="`data:image/png;base64,${icon}`" />
       <div v-if="title">{{ title }}</div>
     </div>
-    <div v-if="children?.length" class="pl-4 mt-1">
-      <UiMapLegendItems :items="children" />
+    <div
+      v-if="children?.length"
+      :class="inline ? 'ml-1' : 'pl-4 mt-1'"
+    >
+      <UiMapLegendItems :items="children" :inline="inline" />
     </div>
   </div>
 </template>
@@ -23,6 +26,10 @@ defineProps({
   children: {
     type: Array<any>,
     default: [],
+  },
+  inline: {
+    type: Boolean,
+    default: false,
   },
 });
 </script>

--- a/src/components/ui/map/legend/Items.vue
+++ b/src/components/ui/map/legend/Items.vue
@@ -1,7 +1,12 @@
 <template>
-  <div class="flex flex-col gap-1">
+  <div :class="inline ? 'flex flex-row flex-wrap gap-x-4 gap-y-1 items-center' : 'flex flex-col gap-1'">
     <div v-for="(data, index) in items" :key="index">
-      <UiMapLegendItem :title="data.title" :icon="data.icon" :children="data.children" />
+      <UiMapLegendItem
+        :title="data.title"
+        :icon="data.icon"
+        :children="data.children"
+        :inline="inline"
+      />
     </div>
   </div>
 </template>
@@ -11,6 +16,10 @@ defineProps({
   items: {
     type: Array<any>,
     default: [],
+  },
+  inline: {
+    type: Boolean,
+    default: false,
   },
 });
 </script>

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -1,5 +1,6 @@
 <template>
-  <div>
+  <div :class="screenshotLayout ? 'flex flex-col h-screen w-screen' : ''">
+    <div :class="screenshotLayout ? 'relative flex-1 min-h-0' : ''">
     <UiMap
       :show-scale-line="true"
       :show-coordinates="true"
@@ -43,7 +44,7 @@
         />
         <UiButtonIcon icon="download" @click="handleExportData()" title="Atsisiųsti duomenis" />
       </template>
-      <template v-if="filtersStore.active" #filtersContent>
+      <template v-if="filtersStore.active && !screenshotLayout" #filtersContent>
         <UiMapLayerToggle v-if="filtersStore.isActive('layers')" :layers="toggleLayers" />
         <Search
           v-else-if="filtersStore.isActive('search')"
@@ -71,6 +72,17 @@
         />
       </template>
     </UiMap>
+    </div>
+    <div
+      v-if="screenshotLayout"
+      class="bg-white border-t border-gray-200 p-3 max-h-[35%] overflow-y-auto"
+    >
+      <UiMapLegend
+        :layer="uetkService.id"
+        title="Sutartiniai ženklai"
+        :visible-only="true"
+      />
+    </div>
     <UiModal
       ref="downloadDataModal"
       title="Duomenų atsisiuntimas"
@@ -183,14 +195,11 @@ const query = parseRouteParams($route.query, [
 ]);
 const isPreview = ref(!!query.preview);
 const isScreenshot = ref(!!query.screenshot);
+const screenshotLayout = computed(() => isPreview.value && isScreenshot.value);
 const parcelId = ref('');
 
 const noResultsModal = ref();
 const downloadDataModal = ref();
-
-if (isPreview.value && isScreenshot.value) {
-  filtersStore.toggle('legend', true);
-}
 
 function onSearch(search: string) {
   filtersStore.search = search;

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -419,6 +419,28 @@ if (query.parcelId) {
   width: 100% !important;
 }
 
+/* UiMap's base styles flip .ol-scale-line / .ol-attribution to
+   position:initial so they don't get caught in the OL absolute
+   layout. That's fine in the regular interactive view where they get
+   portaled into corner mapControls containers, but in screenshot
+   mode they end up at the top of the .ol-viewport. Re-anchor them
+   to the bottom of the map area, just above the legend panel. */
+.screenshot-mode .ol-viewport {
+  position: relative !important;
+}
+.screenshot-mode .ol-scale-line {
+  position: absolute !important;
+  bottom: 4px !important;
+  left: 8px !important;
+  z-index: 5;
+}
+.screenshot-mode .ol-attribution {
+  position: absolute !important;
+  bottom: 4px !important;
+  right: 8px !important;
+  z-index: 5;
+}
+
 .ol-layer {
   cursor: help;
 }

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="screenshotLayout ? 'flex flex-col h-screen w-screen' : ''">
-    <div :class="screenshotLayout ? 'relative flex-1 min-h-0' : ''">
+  <div :class="screenshotLayout ? 'screenshot-mode flex flex-col h-screen w-screen' : ''">
+    <div :class="screenshotLayout ? 'relative flex-1 min-h-0 overflow-hidden' : ''">
     <UiMap
       :show-scale-line="true"
       :show-coordinates="true"
@@ -405,6 +405,17 @@ if (query.parcelId) {
 </script>
 
 <style>
+/* In screenshot mode the OpenLayers map container hard-codes
+   height:100vh; width:100vw via the v-map directive, which overrides
+   our flex layout and pushes the legend off-screen while shifting the
+   scale/attribution into the middle of the page. Constrain it to the
+   parent so the flex column works as designed. */
+.screenshot-mode .ol-viewport,
+.screenshot-mode [style*='100vh'] {
+  height: 100% !important;
+  width: 100% !important;
+}
+
 .ol-layer {
   cursor: help;
 }

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -81,6 +81,7 @@
         :layer="uetkService.id"
         title="Sutartiniai ženklai"
         :visible-only="true"
+        :inline="true"
       />
     </div>
     <UiModal

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -406,11 +406,13 @@ if (query.parcelId) {
 </script>
 
 <style>
-/* In screenshot mode the OpenLayers map container hard-codes
-   height:100vh; width:100vw via the v-map directive, which overrides
-   our flex layout and pushes the legend off-screen while shifting the
-   scale/attribution into the middle of the page. Constrain it to the
-   parent so the flex column works as designed. */
+/* In screenshot mode the v-map directive hard-codes
+   height:100vh; width:100vw on the OL container, which overrides our
+   flex layout and pushes the legend off-screen. Force every wrapper
+   between .flex-1 and the .ol-viewport to fill its parent so the OL
+   map sizes to the available space above the legend. */
+.screenshot-mode .relative.flex-1 > div,
+.screenshot-mode .relative.flex-1 > div > div,
 .screenshot-mode .ol-viewport,
 .screenshot-mode [style*='100vh'] {
   height: 100% !important;

--- a/src/utils/map/layers.ts
+++ b/src/utils/map/layers.ts
@@ -216,12 +216,18 @@ export class MapLayers extends Queues {
     }, {});
   }
 
-  getLegendData(id: string) {
+  getLegendData(id: string, opts: { visibleOnly?: boolean } = {}) {
     const layer = this.getLayer(id);
 
     if (!layer) return;
 
-    const sublayers = this.getAllSublayers(id);
+    const sublayers = opts.visibleOnly
+      ? this.getSublayers(id)
+      : this.getAllSublayers(id);
+
+    if (opts.visibleOnly && !sublayers.length) {
+      return Promise.resolve([]);
+    }
 
     const type = layer.get('type');
     const url = layer?.getSource()?.getUrl();


### PR DESCRIPTION
## Summary
Addresses part 1 of UETK extract issue #4 — legend appearance in the generated PDF map.

- **Legend below the map.** When the route is opened in screenshot mode (`?preview=1&screenshot=1`, used by \`biip-uetk-api/jobs.requests\` when capturing the map for the extract PDF), the *Sutartiniai ženklai* legend is now rendered as a panel **below** the map (flex column, map fills remaining viewport, legend gets its own area). Previously the legend was toggled into the floating overlay panel that sat on top of the map.
- **Visible layers only.** \`MapLayers.getLegendData\` now accepts \`{ visibleOnly: true }\` and uses \`getSublayers\` (active WMS \`LAYERS\` param) instead of \`getAllSublayers\`. The screenshot legend passes that flag, so symbols for layers the user has hidden don't appear. Default callers (interactive legend) keep current behavior.

## Pairs with
- \`biip-uetk-api\` PR #78 — adds the cover header / river label that sit above the screenshot in the extract PDF.

## Test plan
- [ ] Open \`https://maps.biip.lt/uetk?cadastralId=<river>&preview=1&screenshot=1\` and confirm: map fills the upper viewport, legend renders as a clean panel below it (no floating overlay), and only sublayers currently in the WMS request appear in the legend.
- [ ] Open the same route without \`screenshot=1\` and confirm interactive behavior is unchanged (legend still toggleable as overlay panel, full symbol list).
- [ ] Trigger a request PDF generation in the api repo and confirm the captured map screenshot now shows the legend below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)