### PR TITLE
fix: register invasive species action plan layer in gamtotvarka service

### DIFF
--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -1003,6 +1003,7 @@ export const gamtotvarkaService = {
       gamtotvarkaTikslinesProgramos.layer,
       gamtotvarkaVeiksmuPlanai.layer,
       gamtotvarkaStTvarkymoPlanai.layer,
+      gamtotvarkaInvaVeiksmuPlanai.layer,
     ],
   }),
 };


### PR DESCRIPTION
## Aprašymas

Pataisyta klaida, dėl kurios sluoksnis **„Invazinių rūšių reguliavimo veiksmų planas"** (`gamtotvarkaInvaVeiksmuPlanai`) nebuvo atvaizduojamas žemėlapyje gamtotvarkos maršrute, nors jis ir buvo rodomas sluoksnių perjungimo UI.

## Priežastis

`src/utils/layers/theme.ts` faile, `gamtotvarkaService` apibrėžime, sluoksnis buvo įtrauktas į `sublayers` masyvą (naudojamas legendos / perjungimo UI), bet jo `layer` nebuvo įtrauktas į faktinį `LayerGroup` konstruktorių. Todėl OpenLayers sluoksnių medyje šis sluoksnis niekada nebuvo užregistruotas, ir įjungimas iš UI neturėjo jokio efekto.

## Atlikti pakeitimai

- `src/utils/layers/theme.ts`: pridėtas `gamtotvarkaInvaVeiksmuPlanai.layer` į `gamtotvarkaService` `LayerGroup` `layers` masyvą.

## Sluoksnio šaltiniai

Sluoksnis sudarytas iš dviejų WMS potipių iš VSTT gamtotvarkos serviso (`https://wmsgisservice.biomon.lt/opengisservice/gamtotvarka`):

- **Plotai** (`gamtotvarkaInvaVeiksmuPlanuPlotai`): `invaziniu_rusiu_veiksmu_plotai_patvirtintas` / `_rengiamas` / `_negalioja`
- **Teritorijos** (`gamtotvarkaInvaVeiksmuPlanuTeritorijos`): `invaziniu_rusiu_veiksmu_planu_teritorijos_patvirtintas` / `_rengiamas` / `_negalioja`

Potipių perjungimas (Plotai / Teritorijos, statusų filtravimas) veikia per esamą `setSublayers` mechanizmą, kuris rekursyviai eina per `LayerGroup` vaikus — papildomos pataisos nereikia.

## Test plan

- [ ] Atidaryti `gamtotvarka` maršrutą
- [ ] Sluoksnių panelėje įjungti **„Invazinių rūšių reguliavimo veiksmų planas"**
- [ ] Patikrinti, kad žemėlapyje atsiranda Plotai ir Teritorijos
- [ ] Patikrinti, kad veikia statusų filtrai (Patvirtinti / Rengiami / Negalioja)
- [ ] Patikrinti, kad veikia `?gamtotvarkos_planas=<uuid>` query parametras invazinių rūšių planams

🤖 Generated with [Claude Code](https://claude.com/claude-code)