### PR TITLE
feat: enable location tracking on gamtotvarka map

### DIFF
--- a/src/routes/gamtotvarka.vue
+++ b/src/routes/gamtotvarka.vue
@@ -127,6 +127,7 @@ mapLayers
   .add(municipalitiesService.id, { isHidden: true })
   .add(inspireParcelService.id, { isHidden: true })
   .add(invaService.id, { isHidden: true })
+  .enableLocationTracking()
   .click(async ({ coordinate }: any) => {
     selectedFeatures.value = [];
     eventBus.emit('uiSidebar', { open: false });


### PR DESCRIPTION
## Summary
- Pridėta `Mano vieta` (geolokacijos) kontrolė `gamtotvarka` žemėlapyje, kad gamtininkai galėtų orientuotis vietovėje
- Naudojamas tas pats `mapLayers.enableLocationTracking()` metodas, kuris jau veikia kituose maršrutuose (`edit`, `medziokle/edit`, `smalsuolis`, `rusys`, `uetk`, `szns/uetk`, `zuvinimas/draw`)

Closes #198

## Test plan
- [ ] Atidaryti https://maps.biip.lt/gamtotvarka ir patikrinti, kad atsirado `Mano vieta` mygtukas
- [ ] Paspausti mygtuką ir patvirtinti naršyklės geolokacijos prašymą
- [ ] Įsitikinti, kad žemėlapis pakelia į esamą vietą ir rodomas tikslumo apskritimas
- [ ] Patikrinti, kad kitos `gamtotvarka` funkcijos (sluoksnių perjungimas, filtrai, paieška, objektų pasirinkimas) veikia kaip anksčiau

🤖 Generated with [Claude Code](https://claude.com/claude-code)