### PR TITLE
fix: correct polygon area unit conversion in coordinate search

### DIFF
--- a/src/utils/map/coordinates.ts
+++ b/src/utils/map/coordinates.ts
@@ -154,7 +154,7 @@ function toGeoJSON(data: Geometry) {
 }
 
 const formatLength = function (line: LineString) {
-  let length = getLength(line);
+  let length = getLength(line, { projection });
   let unit = 'm';
 
   if (length > 1000) {

--- a/src/utils/map/coordinates.ts
+++ b/src/utils/map/coordinates.ts
@@ -166,15 +166,15 @@ const formatLength = function (line: LineString) {
 };
 
 const formatArea = function (polygon: Polygon) {
-  let length = getArea(polygon);
+  let area = getArea(polygon, { projection });
   let unit = 'm';
 
-  if (length > 10000) {
-    length = length / 10000;
+  if (area > 10000) {
+    area = area / 1000000;
     unit = 'km';
   }
 
-  return `${Math.round(length * 100) / 100} ${unit}<sup>2</sup>`;
+  return `${Math.round(area * 100) / 100} ${unit}<sup>2</sup>`;
 };
 
 export function isCoordinate(input: string, multi: boolean = false) {


### PR DESCRIPTION
## Summary
- Fixes the \"Plotas X km²\" value shown in coordinate-paste search results, which was inflated ~100× because the m²→km² conversion divided by 10 000 (the m²→ha factor) instead of 1 000 000.
- Pass the LKS projection (`EPSG:3346`) to `getArea` so the spherical area is computed for the actual coordinate system instead of OpenLayers' EPSG:3857 default.

## Context
Reported on the INVA observation form: pasting a polygon's LKS coordinates draws it correctly, but the search-result tile claims an area like `5.36 km²` for what is clearly a sub-hectare polygon. The label comes from `formatArea` in `src/utils/map/coordinates.ts`, used in `parseGeomFromString` → `Search/Index.vue` (`description: item.properties?.area`). The on-map measurement label in `src/utils/layers/styles/measurements.ts` already uses the correct `/1 000 000` divisor; this aligns the search-result formatter with it.

## Test plan
- [ ] Open the edit map with polygon search enabled (e.g. INVA request form).
- [ ] Paste polygon coordinates in LKS-94 into the search box.
- [ ] Verify the result tile shows area in km² that matches the on-map measurement label (no more 100× inflation).
- [ ] Verify a small (< 1 ha) polygon shows the m² unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)