### PR TITLE
fix(medziokle/edit): emit features in EPSG:3346 via writeFeatures opts

### DIFF
--- a/src/routes/medziokle/edit.vue
+++ b/src/routes/medziokle/edit.vue
@@ -88,6 +88,7 @@ import {
 } from '@/utils';
 import { getFeatureCollection } from 'geojsonjs';
 import _ from 'lodash';
+import { GeoJSON } from 'ol/format';
 import { computed, inject, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
@@ -233,10 +234,15 @@ mapDraw.value
   .setMulti(!!query.multi)
   .enableBufferSize(!!query.buffer, bufferMin)
   .enableContinuousDraw(enableContinuousDraw)
-  .on(['change', 'remove'], ({ features, featuresJSON }: any) => {
-    if (features) {
-      features = convertFeatureCollectionProjection(features, projection3857, projection);
-    }
+  .on(['change', 'remove'], ({ source, featuresJSON }: any) => {
+    const olFeatures = source?.getFeatures?.() || [];
+    const features = olFeatures.length
+      ? new GeoJSON().writeFeatures(olFeatures, {
+          featureProjection: projection3857,
+          dataProjection: projection,
+          decimals: 2,
+        })
+      : null;
     postMessage('data', features);
     if (!!query.autoZoom && !!featuresJSON?.features?.length) {
       mapLayers.zoomToFeatureCollection(featuresJSON);


### PR DESCRIPTION
## Santrauka

`routes/medziokle/edit.vue` `change/remove` handler'is anksčiau kvietė `convertFeatureCollectionProjection`, kuri viduje šaukia `GeoJSON.writeFeatures` **be `dataProjection` opcijos** — OL grąžina default 4326 koordinates, todėl `postMessage('data', ...)` perduoda WGS84 reikšmes, kurias `biip-medziokle-api` įdeda į 3346-tipo geom stulpelį. PostGIS interpretuoja laipsnius kaip metrus → geometrija toli už Lietuvos ribų (centrinė Prancūzija).

Pakeitimas: vienas tiesioginis `GeoJSON.writeFeatures` su explicit `featureProjection: 3857` + `dataProjection: 3346`. Vienas transform'as, jokių default'ų.

## Prod įtaka

Per **2026-04-27 → 2026-05-18** prarasti **7 pranešimai apie žalą** (6 vilkų, 1 bebrų), nes `boundaries.biip.lt/v1/elderships/search` grąžino 0 atitinkančių seniūnijų off-Lithuania geom'ui, ir `mail.service.ts → notifyDamageElderships()` nepristatė į seniūniją:

| damages.id | data | rūšis | pareiškėjas |
|---|---|---|---|
| 201 | 2026-04-27 | Vilkai | Laura Suraučienė |
| 217 | 2026-04-30 | Vilkai | Stnislovas Gerulskis |
| 224 | 2026-05-05 | Bebrai | Marius Jasėnas |
| 228 | 2026-05-07 | Vilkai | Stepas Čerkauskas |
| 229 | 2026-05-07 | Vilkai | Eimantas Zokaitis |
| 232 | 2026-05-09 | Vilkai | Vidas Gibas |
| 245 | 2026-05-18 | Vilkai | Gintautas Penkauskas |

Šiems atvejams rankiniu būdu paruošti PDF'ai siuntimui į seniūnijas.

## Susiję

Bug'as įvestas commit'u 23ee3e9 (2026-04-24), kuris pakeitė route'o projekciją į EPSG:3857 dėl `huntingServiceVT` rendering'o.

## Test plan

- [x] `yarn run type-check` (vue-tsc --noEmit) — pavyko
- [x] Lint + prettier per pre-commit hook — pavyko
- [ ] Po deploy'aus: pateikti testinį pranešimą per /pranesimas-apie-zala/ ir patikrinti, kad `damages.geom` koordinatės yra LKS-94 zonoje (X 320k–680k, Y 6Mxx)
- [ ] `elderships_notified=true` turi suveikti naujiems pranešimams