### PR TITLE
UETK extract map: more context + visible-layer legend (column, with colons)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,11 @@ $router.isReady().then(() => {
   }
 });
 
-const waitForLegend = (timeoutMs = 5000) =>
+// 10s timeout — the UETK extract screenshot legend fetches one GetLegendGraphic
+// per visible WMS sublayer (~11 layers after basin sublayers were added). At
+// ~300-500ms per fetch on a cold QGIS server, 5s was tight enough to fire the
+// silent-fallback timer for some renders.
+const waitForLegend = (timeoutMs = 10000) =>
   new Promise<void>((resolve) => {
     if (typeof document === "undefined") return resolve();
     if (document.body.dataset.legendReady !== "false") return resolve();

--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -28,6 +28,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  useCurrentScale: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const mapLayers: any = inject('mapLayers');
@@ -43,6 +47,7 @@ if (props.layer) {
   setReadyFlag('false');
   const result = mapLayers.getLegendData(props.layer, {
     visibleOnly: props.visibleOnly,
+    useCurrentScale: props.useCurrentScale,
   });
   if (result && typeof result.then === 'function') {
     result

--- a/src/components/ui/map/legend/Item.vue
+++ b/src/components/ui/map/legend/Item.vue
@@ -2,7 +2,7 @@
   <div :class="inline ? 'flex flex-row flex-wrap gap-x-3 gap-y-1 items-center' : ''">
     <div class="flex items-center gap-2">
       <img v-if="icon" :src="`data:image/png;base64,${icon}`" />
-      <div v-if="title">{{ title }}</div>
+      <div v-if="title">{{ title }}{{ children?.length ? ':' : '' }}</div>
     </div>
     <div
       v-if="children?.length"

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -75,13 +75,12 @@
     </div>
     <div
       v-if="screenshotLayout"
-      class="bg-white border-t border-gray-200 p-3 max-h-[35%] overflow-y-auto"
+      class="bg-white border-t border-gray-200 p-3 max-h-[45%] overflow-y-auto"
     >
       <UiMapLegend
         :layer="uetkService.id"
         title="Sutartiniai ženklai"
         :visible-only="true"
-        :inline="true"
       />
     </div>
     <UiModal
@@ -256,7 +255,18 @@ mapLayers
   .add(sznsUetkService.id, { isHidden: true })
   .add(sznsUetkServiceApproved.id, { isHidden: true })
   .add(sznsUetkServicePreparing.id, { isHidden: true })
-  .add(uetkService.id)
+  .add(uetkService.id);
+
+// In screenshot mode the extract PDF map needs more context than the
+// interactive map's default 8 sublayers: enable upiu_pabaseiniai,
+// upiu_baseinai, upiu_baseinu_rajonai (declared in uetkService.sublayers
+// but not in the default LAYERS CSV) so they render and show up in the
+// legend's visible-only set. Must run after .add() so the source exists.
+if (screenshotLayout.value) {
+  mapLayers.setAllSublayers(uetkService.id);
+}
+
+mapLayers
   .click(async ({ coordinate }: any) => {
     selectedFeatures.value = [];
     selectedGeometries.value = [];
@@ -285,7 +295,7 @@ mapLayers
   })
   .enableLocationTracking();
 
-const filterByCadastralId = async (cadastralId: any) => {
+const filterByCadastralId = async (cadastralId: any, maxZoom?: number) => {
   const layers = mapLayers
     .getAllSublayers(uetkService.id)
     .filter(
@@ -302,11 +312,20 @@ const filterByCadastralId = async (cadastralId: any) => {
     filters.on(item).set('kadastro_id', cadastralId);
   });
 
-  await mapLayers.zoom(uetkService.id, { addStroke: true, filters });
+  await mapLayers.zoom(uetkService.id, { addStroke: true, filters, maxZoom });
 };
 
 if (query.cadastralId) {
-  await filterByCadastralId(query.cadastralId);
+  // For extract-PDF screenshots we cap maxZoom on the fit-to-extent call
+  // itself (rather than calling setZoom after the fact — that loses the
+  // recentering, races with the screenshot's loadend wait, and is dead
+  // anyway because _getZoomLevel returns 10 for EPSG:3346 so any post-fit
+  // currentZoom>13 check never fires). maxZoom 8 is loose enough to show
+  // inflow / outflow rivers + the basin polygons enabled above.
+  await filterByCadastralId(
+    query.cadastralId,
+    screenshotLayout.value ? 8 : undefined,
+  );
 }
 
 events.on('filter', async ({ cadastralId }: any) => {

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -81,6 +81,7 @@
         :layer="uetkService.id"
         title="Sutartiniai ženklai"
         :visible-only="true"
+        :use-current-scale="true"
       />
     </div>
     <UiModal

--- a/src/utils/map/layers.ts
+++ b/src/utils/map/layers.ts
@@ -216,7 +216,10 @@ export class MapLayers extends Queues {
     }, {});
   }
 
-  getLegendData(id: string, opts: { visibleOnly?: boolean } = {}) {
+  getLegendData(
+    id: string,
+    opts: { visibleOnly?: boolean; useCurrentScale?: boolean } = {},
+  ) {
     const layer = this.getLayer(id);
 
     if (!layer) return;
@@ -234,9 +237,22 @@ export class MapLayers extends Queues {
 
     const options = this._getRequestOptions(id);
 
+    // Convert the current OL view resolution into a WMS scale denominator
+    // (units = metres in EPSG:3346, standard CSS DPI = 96). When passed to
+    // GetLegendGraphic, QGIS server drops rules whose scalemindenom/scalemaxdenom
+    // don't bracket this scale — so e.g. the upes "<50 km" tier disappears
+    // from the legend at zoomed-out screenshot scales.
+    let scale: number | undefined;
+    if (opts.useCurrentScale && this.map) {
+      const resolution = this.map.getView().getResolution();
+      if (typeof resolution === 'number' && resolution > 0) {
+        scale = resolution * 96 / 0.0254;
+      }
+    }
+
     let query: any;
     if (type === LayerType.WMS) {
-      query = WMSLegendRequest(sublayers, this.getMapProjection());
+      query = WMSLegendRequest(sublayers, this.getMapProjection(), scale);
     }
 
     if (!query) return;

--- a/src/utils/map/layers.ts
+++ b/src/utils/map/layers.ts
@@ -565,6 +565,7 @@ export class MapLayers extends Queues {
       cb?: Function;
       zoomFn?: Function;
       zoomEmptyFilters?: boolean;
+      maxZoom?: number;
     } = {},
   ): Promise<any> {
     const filters = options?.filters || this.filters(id);
@@ -589,7 +590,11 @@ export class MapLayers extends Queues {
 
     if (!result.length) return;
 
-    this.zoomToFeatureCollection(result, { addStroke: options?.addStroke, cb: options?.zoomFn });
+    this.zoomToFeatureCollection(result, {
+      addStroke: options?.addStroke,
+      cb: options?.zoomFn,
+      maxZoom: options?.maxZoom,
+    });
 
     return result;
   }
@@ -691,7 +696,10 @@ export class MapLayers extends Queues {
     this.map.getView().setZoom(opts?.zoom || this._getZoomLevel());
   }
 
-  zoomToExtent(extent: any, opts: { padding?: number; animate?: boolean } = {}) {
+  zoomToExtent(
+    extent: any,
+    opts: { padding?: number; animate?: boolean; maxZoom?: number } = {},
+  ) {
     if (!extent || !this.map) return;
 
     const width = this.map.getViewport().clientWidth;
@@ -708,7 +716,11 @@ export class MapLayers extends Queues {
     this.map.getView().fit(extent, {
       padding: [padding, padding, padding, padding],
       duration: opts?.animate ? 500 : 0,
-      maxZoom: this._getZoomLevel(),
+      // Explicit maxZoom (e.g. from screenshot mode) overrides the projection
+      // default from _getZoomLevel() — necessary to actually zoom OUT in
+      // EPSG:3346 where _getZoomLevel returns 10, which is already tight for
+      // a single fit-to-feature.
+      maxZoom: typeof opts?.maxZoom === 'number' ? opts.maxZoom : this._getZoomLevel(),
     });
   }
 
@@ -729,6 +741,7 @@ export class MapLayers extends Queues {
       cb?: Function;
       animate?: boolean;
       dataProjection?: string;
+      maxZoom?: number;
     } = {},
   ) {
     if (_.isEmpty(data)) return;
@@ -750,7 +763,10 @@ export class MapLayers extends Queues {
       this.highlightFeatures(data, { layer: fixedHighlightLayerId });
     }
 
-    this.zoomToExtent(extent, { animate: options?.animate });
+    this.zoomToExtent(extent, {
+      animate: options?.animate,
+      maxZoom: options?.maxZoom,
+    });
 
     if (options?.cb && typeof options?.cb === 'function') {
       options.cb();

--- a/src/utils/map/utils.ts
+++ b/src/utils/map/utils.ts
@@ -117,19 +117,32 @@ export function WMSFeatureQuery(query: string, layers: string | string[]) {
   });
 }
 
-export function WMSLegendRequest(layers: string | string[], proj: string = projection) {
+export function WMSLegendRequest(
+  layers: string | string[],
+  proj: string = projection,
+  scale?: number,
+) {
   if (Array.isArray(layers)) {
     layers = layers.join(',');
   }
 
-  return serializeQuery({
+  const params: Record<string, any> = {
     SERVICE: 'WMS',
     VERSION: '1.1.1',
     REQUEST: 'GetLegendGraphic',
     LAYERS: layers,
     FORMAT: 'application/json',
     SRS: proj,
-  });
+  };
+
+  // QGIS server drops rules whose scalemindenom/scalemaxdenom don't match
+  // the requested scale, so the legend lists only the categories actually
+  // rendered at that zoom. Without SCALE every rule comes back regardless.
+  if (typeof scale === 'number' && scale > 0) {
+    params.SCALE = Math.round(scale);
+  }
+
+  return serializeQuery(params);
 }
 
 export function parseRouteParams(params: any, items: string[]) {


### PR DESCRIPTION
## Summary

Three improvements to the screenshot embedded by the extract PDF, driven by post-deploy stakeholder feedback on \`/uetk\` extracts (https://dev-uetk.biip.lt / dev-admin.biip.lt).

### What ships

| Stakeholder ask | Fix |
|---|---|
| Map zoomed too tight — neighbour rivers / inflow + outflow not visible | Extend \`mapLayers.zoom\` with explicit \`maxZoom\`; pass \`maxZoom: 8\` from the route in screenshot mode (\`_getZoomLevel\` returns 10 for EPSG:3346 and can't be loosened by the existing API) |
| Add upiu_pabaseiniai / upiu_baseinai / upiu_baseinu_rajonai layers | \`setAllSublayers(uetkService.id)\` in screenshot branch. Drawn under rivers / lakes by WMS layer order. |
| Legend: visible-only + column layout + colons after Upės / Ežerai | Removed \`:inline=\"true\"\` (column falls back from \`Items.vue\`); bumped panel \`max-h-[35%]\` → \`max-h-[45%]\` to fit basin entries; \`legend/Item.vue\` appends \`:\` to parent titles with children. |
| Legend fetch silent timeout with new basin layers | \`App.vue\` waitForLegend timeout 5s → 10s — ~11 GetLegendGraphic requests now fire per screenshot. |

### What's deferred (separate ticket)

- **River length / lake area symbol differentiation** (>100km vs 50-100km vs <50km lines render identical, lake area squares render identical). Differentiation lives in the QGIS project styling on \`gis.biip.lt/qgisserver/uetk_public\` — neither this repo nor biip-uetk-api can change it. Needs a biip-qgis-server PR / QGIS project update.
- **Landscape PDF orientation** — stakeholder offered as fallback if portrait + bigger viewport isn't enough. Going with portrait 1280×960 (paired biip-uetk-api PR) first; revisit if not enough.

### Side effect (intentional)

The \`legend/Item.vue\` colon edit affects every other \`<UiMapLegend>\` consumer — currently the interactive sidebar legends on \`/uetk\` and both \`/szns/uetk\` legends. Reads as a small typographic improvement for grouped categories; flagging here so reviewers can object.

## Companion PRs

- biip-uetk-api \`extract-map-bigger-screenshot\` — passes \`width: 1280, height: 960\` from the PDF call site through to \`tools.makeScreenshot\`.

## Test plan

- [x] \`yarn build\` clean
- [ ] After deploy: \`/uetk?screenshot=1&preview=1&cadastralId=12211142&hideSidebar=true\` renders with basin layers visible, legend in column with colons, neighbour rivers in frame
- [ ] After biip-uetk-api deploy: trigger a fresh extract request → screenshot is 1280×960 (~50% of A4 portrait content height) → marked object's kadastro_id label readable
- [ ] No regression to interactive \`/uetk\` (sidebar legend now has colons on grouped layers — verify it doesn't look worse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)