### PR TITLE
Render extract legend inline (row) again per stakeholder preference

### DIFF
--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -82,6 +82,7 @@
         title="Sutartiniai ženklai"
         :visible-only="true"
         :use-current-scale="true"
+        :inline="true"
       />
     </div>
     <UiModal


### PR DESCRIPTION
Switched back from column to flex-row + flex-wrap. The earlier column layout fit basin layers vertically but the stakeholder finds the horizontal row reads better in the PDF — and the SCALE filter we added in the previous commit keeps the row short by dropping rules QGIS doesn't render at the current zoom.