### PR TITLE
UETK extract map polish: row legend, scale filter, double-render fix

### DIFF
--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -235,6 +235,17 @@ const toggleLayers = [
   geoportalGrpk,
 ];
 
+// In screenshot mode, switch the UETK layer's WMS LAYERS list to all
+// 11 sublayers BEFORE the layer is added to the map. The previous
+// .add() → setSublayers ordering produced two render passes (8 then
+// 11 layers) and puppeteer captured both, doubling every basin label.
+// setAllSublayers operates on the WMS source created at module load,
+// so it works before .add(); the first render OL queues will already
+// use the full set.
+if (screenshotLayout.value) {
+  mapLayers.setAllSublayers(uetkService.id);
+}
+
 mapLayers
   .addBaseLayer(geoportalTopoGray.id)
   .addBaseLayer(geoportalTopo.id)
@@ -257,18 +268,7 @@ mapLayers
   .add(sznsUetkService.id, { isHidden: true })
   .add(sznsUetkServiceApproved.id, { isHidden: true })
   .add(sznsUetkServicePreparing.id, { isHidden: true })
-  .add(uetkService.id);
-
-// In screenshot mode the extract PDF map needs more context than the
-// interactive map's default 8 sublayers: enable upiu_pabaseiniai,
-// upiu_baseinai, upiu_baseinu_rajonai (declared in uetkService.sublayers
-// but not in the default LAYERS CSV) so they render and show up in the
-// legend's visible-only set. Must run after .add() so the source exists.
-if (screenshotLayout.value) {
-  mapLayers.setAllSublayers(uetkService.id);
-}
-
-mapLayers
+  .add(uetkService.id)
   .click(async ({ coordinate }: any) => {
     selectedFeatures.value = [];
     selectedGeometries.value = [];


### PR DESCRIPTION
## Summary

Follow-up tweaks to the extract map after the merged #203 landed and the stakeholder ran a few more PDF generations. Three small fixes on top of \`extract-map-improvements\`:

| Commit | What |
|---|---|
| 0256a73 | Pass current map scale to GetLegendGraphic so QGIS server filters out rules outside the visible scale range (only the \"> 100 km\" upes tier shows in the legend at maxZoom=8, etc.) |
| 7437eb6 | Restore inline (row) legend layout in the screenshot bottom panel per stakeholder preference — column was harder to scan |
| b2cbd1e | **Move \`setAllSublayers\` BEFORE \`.add()\`** so OL only ever queues one WMS GetMap with the full 11-layer set. The old order produced 8-layer + 11-layer renders that puppeteer captured stacked, doubling every basin label on the screenshot |

## Test plan

- [x] \`yarn build\` clean
- [ ] After deploy, regenerate an extract on dev-uetk → screenshot has only one copy of each basin label (\"VENTOS UPĖS BASEINAS\" once, not twice)
- [ ] Legend renders as a row at the bottom with only the symbols actually visible at the screenshot scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)