### PR TITLE
Wait for post-fit loadend so canvasToImage doesn't catch doubled tiles

### DIFF
--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -328,6 +328,25 @@ if (query.cadastralId) {
     query.cadastralId,
     screenshotLayout.value ? 8 : undefined,
   );
+
+  // In screenshot mode, view.fit kicks off a second tile fetch at the new
+  // extent. mapLayers.waitForLoaded.once('loadend') already resolved on
+  // the initial render, so App.vue's canvasToImage would otherwise fire
+  // while the post-fit tiles are still streaming in — and the canvas
+  // ends up with leftover old tiles plus partial new tiles, doubling
+  // every basin label. Hold the route's async setup open until the
+  // post-fit loadend has fired so Suspense doesn't release until the
+  // canvas is fully painted.
+  if (screenshotLayout.value && mapLayers.map) {
+    await new Promise<void>((resolve) => {
+      const done = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(done, 10000); // safety net
+      mapLayers.map.once('loadend', done);
+    });
+  }
 }
 
 events.on('filter', async ({ cadastralId }: any) => {


### PR DESCRIPTION
PR #205 moved setAllSublayers BEFORE .add() to stop the layer-toggle race, but basin labels still doubled intermittently. Reproduced from diagnostic and tracing — the actual race is in the screenshot capture trigger, not the layer toggle:

  mapLayers.waitForLoaded = new Promise(...map.once('loadend', resolve))

That listener fires once on the FIRST loadend (initial render after .add()), then isLoadedMap stays true forever. After filterByCadastralId runs view.fit() the OL view changes resolution and OL kicks off a second tile fetch — but waitForLoaded already resolved, so as soon as Suspense releases App.vue calls canvasToImage. The canvas at that moment still has the previous render's tiles AND partial new ones. For basin layers whose labels are large and centered, both copies are visible side by side and you get "VENTOS UPĖS BASEINAS" stamped twice.

Fix: hold the route's async setup open until the post-fit loadend has fired, so Suspense (which gates isLoadedSuspense) doesn't release until the canvas is fully painted with the new view's tiles. A 10s safety timer covers the case where view.fit didn't need new tiles.