### PR TITLE
Extract map polish: legend grouping + in-map object label overlay

### DIFF
--- a/src/components/ui/map/legend/Item.vue
+++ b/src/components/ui/map/legend/Item.vue
@@ -1,14 +1,11 @@
 <template>
-  <div :class="inline ? 'flex flex-row flex-wrap gap-x-3 gap-y-1 items-center' : ''">
+  <div class="flex flex-col gap-1">
     <div class="flex items-center gap-2">
       <img v-if="icon" :src="`data:image/png;base64,${icon}`" />
       <div v-if="title">{{ title }}{{ children?.length ? ':' : '' }}</div>
     </div>
-    <div
-      v-if="children?.length"
-      :class="inline ? 'ml-1' : 'pl-4 mt-1'"
-    >
-      <UiMapLegendItems :items="children" :inline="inline" />
+    <div v-if="children?.length" class="pl-4">
+      <UiMapLegendItems :items="children" :inline="false" />
     </div>
   </div>
 </template>

--- a/src/components/ui/map/legend/Items.vue
+++ b/src/components/ui/map/legend/Items.vue
@@ -1,5 +1,14 @@
 <template>
-  <div :class="inline ? 'flex flex-row flex-wrap gap-x-4 gap-y-1 items-center' : 'flex flex-col gap-1'">
+  <!--
+    inline=true (screenshot legend) renders each top-level item as a
+    vertical block (parent + indented children) and wraps blocks
+    horizontally across the row, so the result matches the stakeholder's
+    grouped layout: "Upės ir kanaliai:" / >100 km / 50-100 km / <50 km
+    in one column, "Ežerai ir tvenkiniai:" in the next, single-symbol
+    layers as their own narrow columns. inline=false keeps the original
+    nested vertical list for the sidebar.
+  -->
+  <div :class="inline ? 'flex flex-row flex-wrap gap-x-6 gap-y-2 items-start' : 'flex flex-col gap-1'">
     <div v-for="(data, index) in items" :key="index">
       <UiMapLegendItem
         :title="data.title"


### PR DESCRIPTION
Two follow-ups on the merged #205, both on `extract-map-improvements`.

## Commits

### 1b871ff — Legend: stack parent above children, wrap top-level groups horizontally

Stakeholder showed a reference layout where each tier group ("Upės ir kanaliai:" / >100 km / 50-100 km / <50 km) is its own vertical column, single-symbol layers form their own narrow columns, and the whole strip wraps across the row. Our `inline=true` rendered parent + children INLINE — collapsed every group into one flat strip.

- `Item.vue`: always stack icon+title above children.
- `Items.vue`: `inline=true` flips the OUTER container to `flex-row flex-wrap items-start` so per-item vertical blocks arrange in columns. `inline=false` sidebar layout unchanged.

### 4132cbf — Render extract object's name + kadastro_id as an HTML overlay on the map

QGIS's scale-dependent label rules don't render the object's label at the wide screenshot zoom (maxZoom=8 ≈ 1:300k vs the layer's label scalemaxdenom). Stakeholder asked for the marked object's name + code to appear ON the map (like the QGIS labels of nearby objects), without a colored border.

- After `filterByCadastralId`, compute combined extent of matched features → centroid.
- Build an HTML `<div>` via createElement + textContent (no innerHTML — WMS-supplied name can't introduce XSS) with subtle white-background pill, name in bold + "Identifikavimo kodas: \<code\>".
- Anchor via OL `Overlay` at centroid, `bottom-center` + translate(-50%, -110%) so the label sits just above the marked geometry.
- Name source: `query.label` first (companion biip-uetk-api PR will pass it), fallback to feature `pavadinimas` / `name` property.
- Parse `label` query param via `parseRouteParams`.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: regenerate extract → legend reads as columns of parent + indented children
- [ ] Same extract → the marked river/lake has a white pill above it with its name and Identifikavimo kodas, no green border
- [ ] Sidebar legend on interactive `/uetk` unchanged
- [ ] Sidebar interactive map's getFeatureInfo / click flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)