### PR TITLE
Legend layout (grouped first + columns) + revert in-map overlay

### DIFF
--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -38,6 +38,13 @@ const mapLayers: any = inject('mapLayers');
 
 const legendData = ref([] as any);
 
+// Screenshot legend renders multi-column. Push grouped items (those with
+// children — Ežerai ir tvenkiniai / Upės ir kanalai) to the front so they
+// fill the first columns, and let single-symbol items flow as a tidy
+// trailing column instead of getting strewn across the top row.
+const sortGroupedFirst = (arr: any[]) =>
+  [...arr].sort((a, b) => (b?.children?.length ? 1 : 0) - (a?.children?.length ? 1 : 0));
+
 const setReadyFlag = (value: 'true' | 'false') => {
   if (typeof document === 'undefined') return;
   document.body.dataset.legendReady = value;
@@ -52,7 +59,8 @@ if (props.layer) {
   if (result && typeof result.then === 'function') {
     result
       .then((data: any) => {
-        legendData.value = data || [];
+        const arr = Array.isArray(data) ? data : [];
+        legendData.value = props.inline ? sortGroupedFirst(arr) : arr;
       })
       .finally(() => setReadyFlag('true'));
   } else {

--- a/src/components/ui/map/legend/Items.vue
+++ b/src/components/ui/map/legend/Items.vue
@@ -1,15 +1,23 @@
 <template>
   <!--
-    inline=true (screenshot legend) renders each top-level item as a
-    vertical block (parent + indented children) and wraps blocks
-    horizontally across the row, so the result matches the stakeholder's
-    grouped layout: "Upės ir kanaliai:" / >100 km / 50-100 km / <50 km
-    in one column, "Ežerai ir tvenkiniai:" in the next, single-symbol
-    layers as their own narrow columns. inline=false keeps the original
-    nested vertical list for the sidebar.
+    inline=true (screenshot legend) uses CSS multi-column flow so blocks
+    fill columns top-down then wrap left-to-right. Sorted upstream so
+    grouped items (parent + children — "Ežerai ir tvenkiniai", "Upės ir
+    kanalai") sit in the first columns and single-symbol items pack into
+    a tidy trailing column. break-inside: avoid keeps each parent glued
+    to its children. inline=false keeps the original nested vertical
+    list for the sidebar.
   -->
-  <div :class="inline ? 'flex flex-row flex-wrap gap-x-6 gap-y-2 items-start' : 'flex flex-col gap-1'">
-    <div v-for="(data, index) in items" :key="index">
+  <div
+    :class="inline ? 'columns-2 sm:columns-3 lg:columns-4' : 'flex flex-col gap-1'"
+    :style="inline ? { columnGap: '1.5rem' } : undefined"
+  >
+    <div
+      v-for="(data, index) in items"
+      :key="index"
+      :class="inline ? 'mb-3' : ''"
+      :style="inline ? { breakInside: 'avoid' } : undefined"
+    >
       <UiMapLegendItem
         :title="data.title"
         :icon="data.icon"

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -194,7 +194,6 @@ const query = parseRouteParams($route.query, [
   'preview',
   'screenshot',
   'hideSidebar',
-  'label',
 ]);
 const isPreview = ref(!!query.preview);
 const isScreenshot = ref(!!query.screenshot);
@@ -315,75 +314,7 @@ const filterByCadastralId = async (cadastralId: any, maxZoom?: number) => {
     filters.on(item).set('kadastro_id', cadastralId);
   });
 
-  return mapLayers.zoom(uetkService.id, { addStroke: true, filters, maxZoom });
-};
-
-// Render the extract object's name + kadastro_id as an HTML overlay
-// anchored to the matched geometry. QGIS's scale-dependent label rules
-// don't render the object's label at the wide screenshot zoom, so this
-// gives the stakeholder the "in-map" label they asked for without
-// touching the QGIS project.
-const renderObjectLabel = async (features: any[], cadastralId: string) => {
-  if (!features?.length || !mapLayers.map) return;
-  const { getCenter } = await import('ol/extent');
-  const { default: GeoJSON } = await import('ol/format/GeoJSON');
-  const { Overlay } = await import('ol');
-
-  const fmt = new GeoJSON();
-  const mapProj = mapLayers.map.getView().getProjection();
-  const olFeatures = fmt.readFeatures(
-    { type: 'FeatureCollection', features },
-    { dataProjection: 'EPSG:3346', featureProjection: mapProj },
-  );
-  if (!olFeatures.length) return;
-
-  const first = olFeatures[0];
-  const props = first.getProperties();
-  const name = (query.label as string) || props.pavadinimas || props.name || '';
-  const code = props.kadastro_id || cadastralId;
-
-  // Compute centroid across all matched geometries (handles multi-feature rivers)
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  olFeatures.forEach((f: any) => {
-    const ext = f.getGeometry()?.getExtent();
-    if (!ext) return;
-    minX = Math.min(minX, ext[0]); minY = Math.min(minY, ext[1]);
-    maxX = Math.max(maxX, ext[2]); maxY = Math.max(maxY, ext[3]);
-  });
-  if (!isFinite(minX)) return;
-  const center = getCenter([minX, minY, maxX, maxY]);
-
-  // Build the overlay DOM with createElement/textContent — never innerHTML —
-  // because `name` may originate from a WMS feature property whose contents
-  // we don't fully control.
-  const el = document.createElement('div');
-  el.style.cssText = [
-    'background: rgba(255, 255, 255, 0.92)',
-    'padding: 4px 8px',
-    'border-radius: 3px',
-    'font-family: sans-serif',
-    'font-size: 12px',
-    'line-height: 1.3',
-    'text-align: center',
-    'white-space: nowrap',
-    'pointer-events: none',
-    'transform: translate(-50%, -110%)',
-    'box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15)',
-  ].join(';');
-
-  const nameRow = document.createElement('div');
-  nameRow.style.fontWeight = '700';
-  nameRow.textContent = name || '';
-  el.appendChild(nameRow);
-
-  const codeRow = document.createElement('div');
-  codeRow.appendChild(document.createTextNode('Identifikavimo kodas: '));
-  const codeBold = document.createElement('b');
-  codeBold.textContent = String(code);
-  codeRow.appendChild(codeBold);
-  el.appendChild(codeRow);
-
-  mapLayers.map.addOverlay(new Overlay({ element: el, position: center, positioning: 'bottom-center', stopEvent: false }));
+  await mapLayers.zoom(uetkService.id, { addStroke: true, filters, maxZoom });
 };
 
 if (query.cadastralId) {
@@ -393,14 +324,10 @@ if (query.cadastralId) {
   // anyway because _getZoomLevel returns 10 for EPSG:3346 so any post-fit
   // currentZoom>13 check never fires). maxZoom 8 is loose enough to show
   // inflow / outflow rivers + the basin polygons enabled above.
-  const matched = await filterByCadastralId(
+  await filterByCadastralId(
     query.cadastralId,
     screenshotLayout.value ? 8 : undefined,
   );
-
-  if (screenshotLayout.value) {
-    await renderObjectLabel(matched, String(query.cadastralId));
-  }
 
   // In screenshot mode, view.fit kicks off a second tile fetch at the new
   // extent. mapLayers.waitForLoaded.once('loadend') already resolved on


### PR DESCRIPTION
## Summary

Two commits, both reacting to the freshest stakeholder screenshot of the extract PDF:

1. **Revert #208 (in-map name+kadastras overlay).** After deploy the screenshot showed the marked object's name + identifikavimo kodas are already covered: the preamble above the map carries the full "A - N / Identifikavimo kodas / Vandens telkinys, į kurį įteka" block, and the line itself carries a QGIS-rendered label (e.g. `12210483` + `Aluotis`). A second white pill at the centroid would only duplicate the info. Reverts `4132cbf`.

2. **Legend layout fix.** With the previous `flex-row + flex-wrap + items-start` layout the 6 single-symbol items (Hidroelektrinės, Žuvų pralaidos, Vandens pertekliaus pralaidos, Žemių užtvankos, Vandens tyrimų vietos, Vandens matavimo stotys) stretched across the full row, the two grouped blocks (Ežerai ir tvenkiniai with > 100 / 50-100 / < 50 ha; Upės ir kanalai with > 100 / 50-100 / < 50 km) bumped to the right, and remaining singles (Upių pabaseiniai, Upių baseinai, Upių baseinų rajonai) dangled on a second line — jagged rhythm.

   Switched the screenshot (inline=true) variant to CSS multi-column flow with `break-inside: avoid` so each parent stays glued to its children. Sort upstream in `Index.vue` so grouped items render into the first columns and single-symbol items pack into a tidy trailing column. The sidebar variant (`inline=false`) is untouched.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: regenerate an extract → top of legend = "Ežerai ir tvenkiniai" + "Upės ir kanalai" as parent+children stacks in left columns, then singles flow into the right column(s). No more dangling second row.
- [ ] Sidebar legend (interactive map) still renders as the original nested list.
- [ ] Marked object on the map has just the QGIS label + preamble — no extra white pill on the centroid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)