### PR TITLE
Legend: grouped items as columns + fix icon baseline alignment

### DIFF
--- a/src/components/ui/map/legend/Item.vue
+++ b/src/components/ui/map/legend/Item.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="flex flex-col gap-1">
     <div class="flex items-center gap-2">
-      <img v-if="icon" :src="`data:image/png;base64,${icon}`" />
+      <span class="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+        <img
+          v-if="icon"
+          :src="`data:image/png;base64,${icon}`"
+          class="max-h-full max-w-full object-contain"
+        />
+      </span>
       <div v-if="title">{{ title }}{{ children?.length ? ':' : '' }}</div>
     </div>
     <div v-if="children?.length" class="pl-4">

--- a/src/components/ui/map/legend/Items.vue
+++ b/src/components/ui/map/legend/Items.vue
@@ -1,35 +1,53 @@
 <template>
   <!--
-    inline=true (screenshot legend) uses CSS multi-column flow so blocks
-    fill columns top-down then wrap left-to-right. Sorted upstream so
-    grouped items (parent + children — "Ežerai ir tvenkiniai", "Upės ir
-    kanalai") sit in the first columns and single-symbol items pack into
-    a tidy trailing column. break-inside: avoid keeps each parent glued
-    to its children. inline=false keeps the original nested vertical
-    list for the sidebar.
+    inline=true (screenshot legend): each grouped item (parent + children
+    like "Ežerai ir tvenkiniai", "Upės ir kanalai") becomes its own
+    vertical column at the front; single-symbol items pack into a
+    compact multi-column block at the end. Both kinds share the same
+    horizontal gap so the row reads as one tidy strip.
+
+    inline=false (sidebar) keeps the original nested vertical list.
   -->
-  <div
-    :class="inline ? 'columns-2 sm:columns-3 lg:columns-4' : 'flex flex-col gap-1'"
-    :style="inline ? { columnGap: '1.5rem' } : undefined"
-  >
-    <div
-      v-for="(data, index) in items"
-      :key="index"
-      :class="inline ? 'mb-3' : ''"
-      :style="inline ? { breakInside: 'avoid' } : undefined"
-    >
+  <div v-if="inline" class="flex flex-row flex-wrap items-start gap-x-6 gap-y-3">
+    <div v-for="(data, index) in groupedItems" :key="`g-${index}`">
       <UiMapLegendItem
         :title="data.title"
         :icon="data.icon"
         :children="data.children"
-        :inline="inline"
+        :inline="true"
+      />
+    </div>
+    <div
+      v-if="singleItems.length"
+      class="columns-2 sm:columns-3"
+      :style="{ columnGap: '1.5rem' }"
+    >
+      <div
+        v-for="(data, index) in singleItems"
+        :key="`s-${index}`"
+        class="mb-1"
+        :style="{ breakInside: 'avoid' }"
+      >
+        <UiMapLegendItem :title="data.title" :icon="data.icon" :inline="true" />
+      </div>
+    </div>
+  </div>
+  <div v-else class="flex flex-col gap-1">
+    <div v-for="(data, index) in items" :key="index">
+      <UiMapLegendItem
+        :title="data.title"
+        :icon="data.icon"
+        :children="data.children"
+        :inline="false"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps({
+import { computed } from 'vue';
+
+const props = defineProps({
   items: {
     type: Array<any>,
     default: [],
@@ -39,4 +57,11 @@ defineProps({
     default: false,
   },
 });
+
+const groupedItems = computed(() =>
+  (props.items || []).filter((i: any) => i?.children?.length),
+);
+const singleItems = computed(() =>
+  (props.items || []).filter((i: any) => !i?.children?.length),
+);
 </script>


### PR DESCRIPTION
Follow-up to merged #209 — two issues caught on the latest screenshot:

1. **Hidroelektrinės jumped into the Upės ir kanalai column.** CSS columns balances total height per column, so with [Ežerai, Upės, Hidroelektrinės, Žuvų pralaidos, ...] the browser put Hidroelektrinės at the bottom of the Upės column to even things out — exactly the layout the stakeholder wanted us to avoid.

   Fix: split the screenshot legend into two siblings inside the same flex row — grouped items (those with children) render as their own columns at the front, single-symbol items pack into a trailing `columns-2 sm:columns-3` sub-block. Both share `gap-x-6` so the seam is invisible. Hidroelektrinės now sits with the rest of the singles.

2. **Vandens pertekliaus pralaidos label drifted below the others.** WMS `GetLegendGraphic` returns PNGs of slightly different intrinsic heights (open circle 14px vs filled circle 12px vs triangle outline 16px, etc.). With `items-center` on a flex row, each label's vertical center matched its own icon — so different icon heights = different label baselines.

   Fix in `Item.vue`: wrap the icon in a fixed 20×20 `inline-flex items-center justify-center` slot with `object-contain` on the img. Every label now sits at the same vertical center regardless of intrinsic icon height.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: regenerate an extract → Ežerai + Upės columns at the front; Hidroelektrinės now in the singles sub-block (NOT under Upės); all single-symbol labels share one baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)