### PR TITLE
Legend icon slot: 16x16 + skip placeholder for grouped parents

### DIFF
--- a/src/components/ui/map/legend/Item.vue
+++ b/src/components/ui/map/legend/Item.vue
@@ -1,7 +1,20 @@
 <template>
   <div class="flex flex-col gap-1">
     <div class="flex items-center gap-2">
-      <span class="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+      <!--
+        16x16 slot is enough to hold every WMS legend symbol the layer
+        emits (filled circle, open circle, triangle, line, square fill)
+        without distorting them, and is small enough that the variation
+        between symbol shapes doesn't read as inconsistent left padding.
+        Skip the slot entirely for grouped parents that come back from
+        WMS without an icon, so e.g. "Ežerai ir tvenkiniai:" sits flush
+        with "Upės ir kanalai:" instead of getting pushed 24px right by
+        an empty placeholder.
+      -->
+      <span
+        v-if="icon || !children?.length"
+        class="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+      >
         <img
           v-if="icon"
           :src="`data:image/png;base64,${icon}`"


### PR DESCRIPTION
Follow-up after Playwright check on dev. Two visible alignment issues on the screenshot-mode legend:

1. **Grouped parent labels ("Ežerai ir tvenkiniai:", "Upės ir kanalai:") looked indented vs the singles column.** WMS doesn't return a legend icon for those group nodes, but `Item.vue` was reserving the 20×20 slot regardless — `<span class="h-5 w-5">` with no `<img>` inside still occupies space, so the title got pushed ~28px right (slot + gap). Stakeholder caught it: "Ežerai ir tvenkiniai grupes labelis atrodo vos ne paddinga is kaires turi."

   Skip the slot when the item has no icon AND has children. Grouped parent titles now sit flush at x=0.

2. **"Vandens pertekliaus pralaidos" (open circle) looked offset right vs filled-circle / triangle siblings.** The 20×20 slot was generous for the actual symbol sizes WMS returns (~10–12px). With `object-contain` centering, the open circle's surrounding whitespace inside the slot made the label drift right of the other singles.

   Shrink the slot to 16×16 — still fits the tallest symbol the layer emits, but small enough that ●, ○, ▽, ▼, square, line all read at the same x.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: screenshot-mode legend → "Ežerai" and "Upės" group titles sit flush with each other, no phantom left padding; all single-symbol labels (Hidroelektrinės, Žuvų pralaidos, Vandens pertekliaus pralaidos, Žemių užtvankos, Vandens tyrimų vietos, Vandens matavimo stotys) line up at the same x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)