### PR TITLE
fix(medziokle/edit): pass dataProjection to search-result setFeatures

### DIFF
--- a/src/routes/medziokle/edit.vue
+++ b/src/routes/medziokle/edit.vue
@@ -203,6 +203,10 @@ const selectSearch = (match: any) => {
     .setFeatures(match.geom, {
       append: !!query.multi,
       types: drawTypes.value.map((i) => i.type),
+      // match.geom is in EPSG:3346 (LKS); without dataProjection setFeatures reads it
+      // as the 3857 view projection, so the emit handler double-transforms it
+      // (3857->3346) and the stored point lands outside Lithuania.
+      dataProjection: projection,
     })
     .edit();
 };


### PR DESCRIPTION
## Problema

Žalos pranešimuose (BIIP Medžioklės žurnalas) per `medziokle/edit` iframe žalos vietos taškas, pasirinktas per **koordinačių/adreso paiešką**, buvo įrašomas **už Lietuvos ribų** (rytų Prancūzijoje). Dėl to `boundaries.biip.lt` seniūnijų paieška grąžindavo 0 rezultatų ir `notifyDamageElderships()` niekada nepasiekdavo seniūnijos (`elderships_notified = FALSE`).

## Šakninė priežastis

`selectSearch()` įdeda paieškos rezultatą į draw source per `setFeatures(match.geom, ...)` **be `dataProjection`**. `match.geom` yra EPSG:3346, bet `setFeatures` (`utils/map/draw.ts`) transformuoja tik kai paduotas `dataProjection` — kitaip koordinatės nuskaitomos kaip 3857 (view) projekcija. Vėliau `change/remove` emit handleris rašo `featureProjection: 3857 -> dataProjection: 3346`, taip **dvigubai transformuodamas** jau 3346 esantį tašką ir nustumdamas jį už Lietuvos.

Tai ta pati klaidų klasė kaip ankstesnis draw-emit fix `f5eadfc`, tik per paieškos kelią.

## Poveikis (prod)

8 žalos pranešimai prarasti 2026-04-27 … 2026-06-09 (id 201, 217, 224, 228, 229, 232, 245, 268) — visi su tikra LT vieta, bet saugomu tašku Prancūzijoje. Atvirkštinė transformacija atstato tikras vietas (pvz. 268 → Žemaitkiemis, Ukmergės r.).

## Pataisymas

Paduoti `dataProjection: projection` (EPSG:3346) `selectSearch` `setFeatures` iškvietime — taip pat, kaip jau daroma `events.on('geom')` iškvietime tame pačiame faile.

## Pastaba (sekantys žingsniai, ne šiame PR)

- Tas pats praleidimas yra ir kituose route'uose (`routes/edit.vue:209`, `routes/rusys.vue:390`) — verta audituoti.
- Siūloma `setFeatures` (`draw.ts`) sutvirtinti: visada nustatyti `featureProjection = view`, o `dataProjection` numatyti į duomenų CRS, kad praleistas parametras nebegalėtų sukelti netransformuoto nuskaitymo.
- Serverio pusėje (`biip-medziokle-api` `damages.createPublic`) pridėti `geom ∈ Lietuva` validaciją kaip gynybą.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
