### PR TITLE
ci: run CI/deploy jobs on self-hosted am-github-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: am-github-runner
     timeout-minutes: 15
 
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   validate-docker-build:
     name: Validate if docker image builds
-    runs-on: ubuntu-latest
+    runs-on: am-github-runner
     steps:
       - uses: actions/checkout@v3
 
@@ -85,7 +85,7 @@ jobs:
 
   publish-preview:
     name: Publish preview
-    runs-on: ubuntu-latest
+    runs-on: am-github-runner
     if: github.event_name == 'pull_request'
     timeout-minutes: 10
     needs: build-test


### PR DESCRIPTION
## Kodėl

Org Actions spending limit blokuoja GitHub-hosted runnerius (`job was not started because recent account payments have failed or your spending limit needs to be increased`). Vakar dėl to krito HR deploy'ai. Standartas — naudoti jau egzistuojantį self-hosted `am-github-runner` (ARC, Default runner group, matomas visiems org repams).

## Kas pakeista

Inline CI/deploy jobų `runs-on: ubuntu-latest` → `am-github-runner`.

- Saugumo skenai (CodeQL / Checkov / Scorecards) **palikti** ant `ubuntu-latest`.
- Deploy'ai per reusable workflow'us automatiškai migruoja per **AplinkosMinisterija/reusable-workflows#32** (`runs-on` default flip) — jiems atskiro pakeitimo nereikia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)