### PR TITLE
extract map: cap maxZoom at 14 so small features stay readable

### DIFF
--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -322,11 +322,18 @@ if (query.cadastralId) {
   // itself (rather than calling setZoom after the fact — that loses the
   // recentering, races with the screenshot's loadend wait, and is dead
   // anyway because _getZoomLevel returns 10 for EPSG:3346 so any post-fit
-  // currentZoom>13 check never fires). maxZoom 8 is loose enough to show
-  // inflow / outflow rivers + the basin polygons enabled above.
+  // currentZoom>13 check never fires).
+  //
+  // maxZoom is an UPPER BOUND on view.fit, not a forced zoom. Big
+  // features (Nemunas, Nevėžis, ...) still pick the smaller zoom they
+  // need to fit their extent into the viewport — the cap doesn't bite.
+  // Small features (a 200m pond, a 5km stream) used to bottom out at
+  // the cap with the actual geometry showing as a single highlight
+  // pixel; bumping the cap from 8 → 14 lets them zoom in to a readable
+  // size while leaving the big-feature path untouched.
   await filterByCadastralId(
     query.cadastralId,
-    screenshotLayout.value ? 8 : undefined,
+    screenshotLayout.value ? 14 : undefined,
   );
 
   // In screenshot mode, view.fit kicks off a second tile fetch at the new


### PR DESCRIPTION
Stakeholder feedback on the extract PDF map:

> Mažiems ežerams ir upėms išrašo žemėlapio mastelį suformuoti tinkamą, nes dabar jie vos įžiūrimi (pridėti išrašai Novenos ir Varlažerio).

Small lakes / short streams render as a single highlight pixel because the screenshot-mode `view.fit` cap is `maxZoom: 8`, well below the zoom the geometry needs for a readable size. The stroke is the only visible cue and the QGIS-rendered LT label gets dropped at that scale rule.

## Fix

Bump `maxZoom` from 8 → 14 in `routes/uetk.vue` for screenshot mode.

`maxZoom` on `view.fit` is an **upper bound**, not a forced zoom:

| Feature | idealZoom (to fit extent) | cap=8 (was) | cap=14 (now) |
|---|---|---|---|
| Nemunas (~900 km) | 6 | 6 | **6** — unchanged |
| Nevėžis (~210 km) | 8 | 8 | **8** — unchanged |
| A-1 stream (~5 km) | 14 | 8 (clamped, dot) | **14** — readable |
| Mažas ežeras (~200 m) | 17 | 8 (dot) | **14** (cap) — readable |

Big-feature path doesn't move — view.fit still picks the smaller zoom needed to fit the full extent. The cap only kicks in for features that were previously clamped, which is exactly the set the stakeholder named.

## Test plan

- [x] `yarn type-check` + `yarn build-only` clean
- [ ] After deploy: extract for Novena / Varlažeris → marked feature visible (not a single pixel), QGIS label appears (its scalemaxdenom rule fires at the higher zoom)
- [ ] Nemunas extract → still shows full river end-to-end (no over-zoom)
- [ ] Mid-size river (Nevėžis-ish) → fits as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)