### PR TITLE
extract map: bump screenshot maxZoom 14 → 17 (small features readable)

### DIFF
--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -333,7 +333,7 @@ if (query.cadastralId) {
   // size while leaving the big-feature path untouched.
   await filterByCadastralId(
     query.cadastralId,
-    screenshotLayout.value ? 14 : undefined,
+    screenshotLayout.value ? 17 : undefined,
   );
 
   // In screenshot mode, view.fit kicks off a second tile fetch at the new

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -318,19 +318,6 @@ const filterByCadastralId = async (cadastralId: any, maxZoom?: number) => {
 };
 
 if (query.cadastralId) {
-  // For extract-PDF screenshots we cap maxZoom on the fit-to-extent call
-  // itself (rather than calling setZoom after the fact — that loses the
-  // recentering, races with the screenshot's loadend wait, and is dead
-  // anyway because _getZoomLevel returns 10 for EPSG:3346 so any post-fit
-  // currentZoom>13 check never fires).
-  //
-  // maxZoom is an UPPER BOUND on view.fit, not a forced zoom. Big
-  // features (Nemunas, Nevėžis, ...) still pick the smaller zoom they
-  // need to fit their extent into the viewport — the cap doesn't bite.
-  // Small features (a 200m pond, a 5km stream) used to bottom out at
-  // the cap with the actual geometry showing as a single highlight
-  // pixel; bumping the cap from 8 → 14 lets them zoom in to a readable
-  // size while leaving the big-feature path untouched.
   await filterByCadastralId(
     query.cadastralId,
     screenshotLayout.value ? 17 : undefined,


### PR DESCRIPTION
Follow-up to [#214](https://github.com/AplinkosMinisterija/biip-maps-web/pull/214). At cap=14, short streams like Novena (`cadastralId=12110006`, ~500m) still rendered as a thin line between surrounding lakes — readable, but not what a stakeholder would want as the main subject of an extract page.

Bump to **17** (building-detail zoom). `maxZoom` stays an upper bound — big features (Nemunas ~6, Nevėžis ~8) keep picking their fit-to-extent zoom; only previously-clamped small features zoom further in.

## Test plan

- [x] `yarn type-check` + `yarn build-only` clean
- [ ] After deploy: Novena / Varlažeris extract → marked geometry visibly fills a fair share of the viewport
- [ ] Nemunas extract still shows full river
- [ ] Mid-size river (Nevėžis-class) still fits

🤖 Generated with [Claude Code](https://claude.com/claude-code)