### PR TITLE
uetk legend: swap zemiu_uztvanka ↔ vandens_pertekliaus_pralaida order

### DIFF
--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -139,7 +139,7 @@ export const uetkService = {
 
   layer: getWMSImageLayer(
     `${qgisServerUrl}/uetk_public`,
-    'upes,ezerai_tvenkiniai,vandens_matavimo_stotys,vandens_tyrimu_vietos,vandens_pertekliaus_pralaida,zemiu_uztvanka,zuvu_pralaida,hidroelektrines',
+    'upes,ezerai_tvenkiniai,vandens_matavimo_stotys,vandens_tyrimu_vietos,zemiu_uztvanka,vandens_pertekliaus_pralaida,zuvu_pralaida,hidroelektrines',
     `${aaaCopyright} ${biipCopyright}`,
   ),
 };

--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -120,12 +120,12 @@ export const uetkService = {
       name: 'Vandens tyrimų vietos',
     },
     {
-      value: 'zemiu_uztvanka',
-      name: 'Žemių užtvanka',
-    },
-    {
       value: 'vandens_pertekliaus_pralaida',
       name: 'Vandens pertekliaus pralaida',
+    },
+    {
+      value: 'zemiu_uztvanka',
+      name: 'Žemių užtvanka',
     },
     {
       value: 'zuvu_pralaida',
@@ -139,7 +139,7 @@ export const uetkService = {
 
   layer: getWMSImageLayer(
     `${qgisServerUrl}/uetk_public`,
-    'upes,ezerai_tvenkiniai,vandens_matavimo_stotys,vandens_tyrimu_vietos,zemiu_uztvanka,vandens_pertekliaus_pralaida,zuvu_pralaida,hidroelektrines',
+    'upes,ezerai_tvenkiniai,vandens_matavimo_stotys,vandens_tyrimu_vietos,vandens_pertekliaus_pralaida,zemiu_uztvanka,zuvu_pralaida,hidroelektrines',
     `${aaaCopyright} ${biipCopyright}`,
   ),
 };


### PR DESCRIPTION
Stakeholder wanted the two single-symbol items shown in the opposite order in the extract legend.

Order comes from `uetkService.sublayers[]` — the `GetLegendGraphic` query lists `LAYERS=...` in that order and QGIS server returns nodes in the same order. The matching `LAYERS` string on the WMS layer is bumped too so `GetMap` stacking stays consistent.

## Diff

```diff
sublayers: [
   ...
   { value: 'vandens_tyrimu_vietos', ... },
-  { value: 'zemiu_uztvanka', ... },
-  { value: 'vandens_pertekliaus_pralaida', ... },
+  { value: 'vandens_pertekliaus_pralaida', ... },
+  { value: 'zemiu_uztvanka', ... },
   { value: 'zuvu_pralaida', ... },
   ...
]

LAYERS=
- ...vandens_tyrimu_vietos,zemiu_uztvanka,vandens_pertekliaus_pralaida,zuvu_pralaida,...
+ ...vandens_tyrimu_vietos,vandens_pertekliaus_pralaida,zemiu_uztvanka,zuvu_pralaida,...
```

## Test plan

- [x] `yarn type-check` + `yarn build-only` clean
- [ ] After deploy: extract screenshot legend shows `Vandens pertekliaus pralaidos` BEFORE `Žemių užtvankos` in the singles row

🤖 Generated with [Claude Code](https://claude.com/claude-code)