### PR TITLE
uetk legend: explicit order + columns-3 continuous flow

### DIFF
--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -39,18 +39,37 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  // Optional explicit ordering for legend items by title. Items present
+  // in the array sort by their index here; anything QGIS emits that the
+  // caller didn't anticipate falls to the end in QGIS-native order.
+  // Used by the extract-PDF route to lock the print legend into the
+  // stakeholder-approved 4-4-3 column layout regardless of what the
+  // uetk_print project happens to emit.
+  legendOrder: {
+    type: Array as () => string[],
+    default: () => [],
+  },
 });
 
 const mapLayers: any = inject('mapLayers');
 
 const legendData = ref([] as any);
 
-// Screenshot legend renders multi-column. Push grouped items (those with
-// children — Ežerai ir tvenkiniai / Upės ir kanalai) to the front so they
-// fill the first columns, and let single-symbol items flow as a tidy
-// trailing column instead of getting strewn across the top row.
+// Screenshot legend renders multi-column. Without an explicit order
+// (legendOrder prop empty), push grouped items first so they fill the
+// leftmost columns and singles pack into a tidy trailing block.
 const sortGroupedFirst = (arr: any[]) =>
   [...arr].sort((a, b) => (b?.children?.length ? 1 : 0) - (a?.children?.length ? 1 : 0));
+
+const sortByExplicitOrder = (arr: any[], order: string[]) => {
+  const rank = new Map(order.map((title, i) => [title, i]));
+  const fallback = order.length;
+  return [...arr].sort((a, b) => {
+    const ai = rank.has(a?.title) ? (rank.get(a.title) as number) : fallback;
+    const bi = rank.has(b?.title) ? (rank.get(b.title) as number) : fallback;
+    return ai - bi;
+  });
+};
 
 const setReadyFlag = (value: 'true' | 'false') => {
   if (typeof document === 'undefined') return;
@@ -68,7 +87,13 @@ if (props.layer) {
     result
       .then((data: any) => {
         const arr = Array.isArray(data) ? data : [];
-        legendData.value = props.inline ? sortGroupedFirst(arr) : arr;
+        if (!props.inline) {
+          legendData.value = arr;
+        } else if (props.legendOrder.length) {
+          legendData.value = sortByExplicitOrder(arr, props.legendOrder);
+        } else {
+          legendData.value = sortGroupedFirst(arr);
+        }
       })
       .finally(() => setReadyFlag('true'));
   } else {

--- a/src/components/ui/map/legend/Items.vue
+++ b/src/components/ui/map/legend/Items.vue
@@ -1,35 +1,25 @@
 <template>
   <!--
-    inline=true (screenshot legend): each grouped item (parent + children
-    like "Ežerai ir tvenkiniai", "Upės ir kanalai") becomes its own
-    vertical column at the front; single-symbol items pack into a
-    compact multi-column block at the end. Both kinds share the same
-    horizontal gap so the row reads as one tidy strip.
+    inline=true (screenshot legend): every item flows top-to-bottom into
+    one 3-column CSS columns block so the browser auto-balances the
+    list (e.g. 11 items → 4-4-3). The parent decides the order via
+    legendOrder; this component just respects it.
 
     inline=false (sidebar) keeps the original nested vertical list.
   -->
-  <div v-if="inline" class="flex flex-row flex-wrap items-start gap-x-6 gap-y-3">
-    <div v-for="(data, index) in groupedItems" :key="`g-${index}`">
+  <div v-if="inline" class="columns-3" :style="{ columnGap: '1.5rem' }">
+    <div
+      v-for="(data, index) in items"
+      :key="index"
+      class="mb-1"
+      :style="{ breakInside: 'avoid' }"
+    >
       <UiMapLegendItem
         :title="data.title"
         :icon="data.icon"
         :children="data.children"
         :inline="true"
       />
-    </div>
-    <div
-      v-if="singleItems.length"
-      class="columns-2 sm:columns-3"
-      :style="{ columnGap: '1.5rem' }"
-    >
-      <div
-        v-for="(data, index) in singleItems"
-        :key="`s-${index}`"
-        class="mb-1"
-        :style="{ breakInside: 'avoid' }"
-      >
-        <UiMapLegendItem :title="data.title" :icon="data.icon" :inline="true" />
-      </div>
     </div>
   </div>
   <div v-else class="flex flex-col gap-1">
@@ -45,9 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-
-const props = defineProps({
+defineProps({
   items: {
     type: Array<any>,
     default: [],
@@ -57,11 +45,4 @@ const props = defineProps({
     default: false,
   },
 });
-
-const groupedItems = computed(() =>
-  (props.items || []).filter((i: any) => i?.children?.length),
-);
-const singleItems = computed(() =>
-  (props.items || []).filter((i: any) => !i?.children?.length),
-);
 </script>

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -84,6 +84,7 @@
         :use-current-scale="true"
         :inline="true"
         :legend-url="uetkService.legendUrl"
+        :legend-order="uetkService.legendOrder"
       />
     </div>
     <UiModal

--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -147,6 +147,26 @@ export const uetkService = {
   // interactive-map clutter). GetMap tiles still come from uetk_public
   // above — only the screenshot legend swaps to uetk_print.
   legendUrl: `${qgisServerUrl}/uetk_print`,
+  // Explicit print-legend order. The uetk_print QGIS project returns
+  // these 11 categories in its own internal order; the stakeholder
+  // wants them grouped by domain — base geography first, point
+  // hydro-structures next, administrative basins last — so the
+  // columns-3 layout packs into a meaningful 4-4-3 grid. Sort happens
+  // in <UiMapLegend> after the GetLegendGraphic fetch; names must
+  // match exactly what QGIS emits.
+  legendOrder: [
+    'Upės ir kanalai',
+    'Ežerai ir tvenkiniai',
+    'Vandens tyrimų vietos',
+    'Vandens matavimo stotys',
+    'Hidroelektrinės',
+    'Žuvų pralaidos',
+    'Žemių užtvankos',
+    'Vandens pertekliaus pralaidos',
+    'Upių pabaseiniai',
+    'Upių baseinai',
+    'Upių baseinų rajonai',
+  ],
 };
 
 export const sznsUetkServiceApproved = {


### PR DESCRIPTION
## Why
Stakeholder asked for the print legend to read as three fixed-content columns — geographic base layers / point hydro-structures / administrative basin boundaries — instead of the current "grouped items first / singles packed at the end" shape.

## Changes
1. **\`uetkService.legendOrder\`** (\`theme.ts\`): explicit ordering for the 11 categories \`uetk_print\` emits. Sort happens in \`<UiMapLegend>\` after the GetLegendGraphic fetch.
2. **\`UiMapLegend\`** (\`Index.vue\`): new \`legendOrder\` prop. When supplied (and \`inline=true\`), items sort by their position in the array — otherwise existing \`sortGroupedFirst\` behavior is preserved for other consumers.
3. **\`UiMapLegendItems\`** (\`Items.vue\`) inline mode: drop the \`groupedItems first + singles packed\` split. All items now flow into one \`columns-3\` CSS block — the browser auto-balances 11 items into a 4-4-3 grid matching the stakeholder mock.

## Test plan
- [ ] Render \`/uetk?screenshot=1&preview=1&cadastralId=12110006\` on staging → legend reads:
      Col 1: Upės ir kanalai · Ežerai ir tvenkiniai · Vandens tyrimų vietos · Vandens matavimo stotys
      Col 2: Hidroelektrinės · Žuvų pralaidos · Žemių užtvankos · Vandens pertekliaus pralaidos
      Col 3: Upių pabaseiniai · Upių baseinai · Upių baseinų rajonai
- [ ] Sidebar (non-inline) legends in other routes still render unchanged (nested vertical list).
- [ ] Extract PDF regenerated → legend block in the saved screenshot matches the stakeholder mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)