### PR TITLE
Revert uetk sublayer swap (zemiu_uztvanka ↔ vandens_pertekliaus_pralaida)

### DIFF
--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -120,12 +120,12 @@ export const uetkService = {
       name: 'Vandens tyrimų vietos',
     },
     {
-      value: 'vandens_pertekliaus_pralaida',
-      name: 'Vandens pertekliaus pralaida',
-    },
-    {
       value: 'zemiu_uztvanka',
       name: 'Žemių užtvanka',
+    },
+    {
+      value: 'vandens_pertekliaus_pralaida',
+      name: 'Vandens pertekliaus pralaida',
     },
     {
       value: 'zuvu_pralaida',


### PR DESCRIPTION
## Why
Stakeholder is moving print-legend ordering authority to the \`uetk_print\` QGIS project (single source of truth). Vue-side sublayer reordering is no longer the right lever.

## Change
Revert 31e34c3 — put \`uetkService.sublayers\` back the way it was: \`zemiu_uztvanka\` first, \`vandens_pertekliaus_pralaida\` second.

## Test plan
- [ ] UETK layer toggle in the sidebar lists sublayers in the pre-31e34c3 order.
- [ ] Print legend on the extract-PDF route reads whatever order the \`uetk_print\` QGIS project emits (no Vue interference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)