### PR TITLE
uetk sublayers: reorder to match uetk_print legend draw stack

### DIFF
--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -90,6 +90,13 @@ export const uetkService = {
   id: 'uetkService',
   title: 'UETK',
   description: [aaaCopyright, biipCopyright],
+  // Order matches the LAYERS query the qgis-server uetk_print project
+  // expects: admin basins first, then point hydro-structures, then base
+  // geography last. QGIS reverses LAYERS into legend draw order (last
+  // requested → first displayed), so the print legend reads top-down
+  // as Upės → Ežerai → ... → Upių baseinų rajonai. Sidebar layer
+  // toggle and visible-only legend reuse the same array, so any reorder
+  // here also moves them.
   sublayers: [
     {
       value: 'upiu_baseinu_rajonai',
@@ -104,12 +111,20 @@ export const uetkService = {
       name: 'Upių pabaseiniai',
     },
     {
-      value: 'upes',
-      name: 'Upės',
+      value: 'vandens_pertekliaus_pralaida',
+      name: 'Vandens pertekliaus pralaida',
     },
     {
-      value: 'ezerai_tvenkiniai',
-      name: 'Ežerai ir tvenkiniai',
+      value: 'zemiu_uztvanka',
+      name: 'Žemių užtvanka',
+    },
+    {
+      value: 'zuvu_pralaida',
+      name: 'Žuvų pralaida',
+    },
+    {
+      value: 'hidroelektrines',
+      name: 'Hidroelektrinės',
     },
     {
       value: 'vandens_matavimo_stotys',
@@ -120,20 +135,12 @@ export const uetkService = {
       name: 'Vandens tyrimų vietos',
     },
     {
-      value: 'zemiu_uztvanka',
-      name: 'Žemių užtvanka',
+      value: 'ezerai_tvenkiniai',
+      name: 'Ežerai ir tvenkiniai',
     },
     {
-      value: 'vandens_pertekliaus_pralaida',
-      name: 'Vandens pertekliaus pralaida',
-    },
-    {
-      value: 'zuvu_pralaida',
-      name: 'Žuvų pralaida',
-    },
-    {
-      value: 'hidroelektrines',
-      name: 'Hidroelektrinės',
+      value: 'upes',
+      name: 'Upės',
     },
   ],
 


### PR DESCRIPTION
## Why
biip-maps-web dev shipped a tuned \`uetk_print\` QGIS project on staging and asked us to align our \`LAYERS\` query so the print legend reads in the stakeholder-approved order. QGIS-server reverses \`LAYERS\` into draw-stack order (last requested → first displayed), so the array here ends with the layers that should appear first in the legend.

## Reference
Verified live: https://staging-gis.biip.lt/qgisserver/uetk_print?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYERS=upiu_baseinu_rajonai,upiu_baseinai,upiu_pabaseiniai,vandens_pertekliaus_pralaida,zemiu_uztvanka,zuvu_pralaida,hidroelektrines,vandens_matavimo_stotys,vandens_tyrimu_vietos,ezerai_tvenkiniai,upes&FORMAT=application/json&SRS=EPSG:3346

→ returns nodes in: Upės · Ežerai · Vandens tyrimų vietos · Vandens matavimo stotys · Hidroelektrinės · Žuvų pralaidos · Žemių užtvankos · Vandens pertekliaus pralaidos · Upių pabaseiniai · Upių baseinai · Upių baseinų rajonai.

## Side effect
The same \`sublayers[]\` array also feeds the sidebar layer toggle and the visible-only legend list, so those sidebars now also list admin → hydro-structures → base-geography. Intentional — the print-legend layout is the source of truth now.

## Test plan
- [ ] Extract-PDF screenshot on staging reads top-down: Upės, Ežerai, Vandens tyrimų vietos, Vandens matavimo stotys, Hidroelektrinės, Žuvų pralaidos, Žemių užtvankos, Vandens pertekliaus pralaidos, Upių pabaseiniai, Upių baseinai, Upių baseinų rajonai.
- [ ] Sidebar UETK layer toggle still works (sublayer values unchanged — only order moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)