### PR TITLE
uetk legend: separate uetk_print LAYERS order from uetk_public draw stack

### DIFF
--- a/src/components/ui/map/legend/Index.vue
+++ b/src/components/ui/map/legend/Index.vue
@@ -39,6 +39,14 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  // Optional explicit LAYERS list for GetLegendGraphic. When supplied,
+  // bypasses the layer's sublayers[] (which doubles as the sidebar
+  // toggle list and the live WMS draw stack) so the print-legend
+  // order can be chosen independently of how the map renders.
+  legendLayersOrder: {
+    type: Array as () => string[],
+    default: () => [],
+  },
 });
 
 const mapLayers: any = inject('mapLayers');
@@ -63,6 +71,7 @@ if (props.layer) {
     visibleOnly: props.visibleOnly,
     useCurrentScale: props.useCurrentScale,
     legendUrl: props.legendUrl || undefined,
+    legendLayersOrder: props.legendLayersOrder.length ? props.legendLayersOrder : undefined,
   });
   if (result && typeof result.then === 'function') {
     result

--- a/src/routes/uetk.vue
+++ b/src/routes/uetk.vue
@@ -84,6 +84,7 @@
         :use-current-scale="true"
         :inline="true"
         :legend-url="uetkService.legendUrl"
+        :legend-layers-order="uetkService.legendLayersOrder"
       />
     </div>
     <UiModal

--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -147,6 +147,27 @@ export const uetkService = {
   // interactive-map clutter). GetMap tiles still come from uetk_public
   // above — only the screenshot legend swaps to uetk_print.
   legendUrl: `${qgisServerUrl}/uetk_print`,
+  // LAYERS list sent to GetLegendGraphic against uetk_print. KEPT
+  // SEPARATE from sublayers[] on purpose: sublayers[] doubles as the
+  // sidebar layer toggle list AND the LAYERS payload that
+  // setAllSublayers writes onto the uetk_public WMS source in
+  // screenshot mode (routes/uetk.vue:246) — reordering it would flip
+  // the live uetk_public draw stack. This array only affects the print
+  // legend's left-to-right column order (QGIS-server reverses LAYERS
+  // into legend draw order: last requested → first displayed).
+  legendLayersOrder: [
+    'upiu_baseinu_rajonai',
+    'upiu_baseinai',
+    'upiu_pabaseiniai',
+    'vandens_pertekliaus_pralaida',
+    'zemiu_uztvanka',
+    'zuvu_pralaida',
+    'hidroelektrines',
+    'vandens_matavimo_stotys',
+    'vandens_tyrimu_vietos',
+    'ezerai_tvenkiniai',
+    'upes',
+  ],
 };
 
 export const sznsUetkServiceApproved = {

--- a/src/utils/map/layers.ts
+++ b/src/utils/map/layers.ts
@@ -222,17 +222,25 @@ export class MapLayers extends Queues {
       visibleOnly?: boolean;
       useCurrentScale?: boolean;
       legendUrl?: string;
+      legendLayersOrder?: string[];
     } = {},
   ) {
     const layer = this.getLayer(id);
 
     if (!layer) return;
 
-    const sublayers = opts.visibleOnly
-      ? this.getSublayers(id)
-      : this.getAllSublayers(id);
+    // legendLayersOrder override lets a caller dictate the LAYERS list
+    // sent to GetLegendGraphic independently of sublayers[]. Needed
+    // when sublayers[] doubles as the live WMS draw stack (e.g.
+    // uetkService) and we want a different order on a print-legend
+    // QGIS project without disturbing the map.
+    const sublayers = opts.legendLayersOrder?.length
+      ? opts.legendLayersOrder
+      : opts.visibleOnly
+        ? this.getSublayers(id)
+        : this.getAllSublayers(id);
 
-    if (opts.visibleOnly && !sublayers.length) {
+    if (opts.visibleOnly && !opts.legendLayersOrder?.length && !sublayers.length) {
       return Promise.resolve([]);
     }
 


### PR DESCRIPTION
## Why
Stakeholder wants the extract-PDF print legend in a specific column order. Earlier attempt (closed #221) reordered \`uetkService.sublayers[]\`, but that array also drives \`setAllSublayers\` in screenshot mode (\`routes/uetk.vue:246-248\`) which writes the live \`uetk_public\` WMS LAYERS payload — so reordering it flipped the map's draw stack too. Wrong lever.

## What
A new \`uetkService.legendLayersOrder\` array, used ONLY for GetLegendGraphic against \`uetk_print\`. \`sublayers[]\` is untouched.

## Changes
- \`theme.ts\` — \`uetkService.legendLayersOrder: string[]\` (11 entries; QGIS-server reverses LAYERS into legend draw order, so the array ends with \`upes\` → legend starts with "Upės").
- \`layers.ts\` \`getLegendData()\` — new \`opts.legendLayersOrder\`; when supplied, it replaces the \`sublayers\` lookup used by \`WMSLegendRequest\`. Visible-only filter is bypassed (the print legend wants the full curated set).
- \`Index.vue\` (\`<UiMapLegend>\`) — new \`legendLayersOrder\` prop, forwarded through.
- \`uetk.vue\` — passes \`:legend-layers-order\` to the screenshot legend.

## Reference URL
https://staging-gis.biip.lt/qgisserver/uetk_print?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYERS=upiu_baseinu_rajonai,upiu_baseinai,upiu_pabaseiniai,vandens_pertekliaus_pralaida,zemiu_uztvanka,zuvu_pralaida,hidroelektrines,vandens_matavimo_stotys,vandens_tyrimu_vietos,ezerai_tvenkiniai,upes&FORMAT=application/json&SRS=EPSG:3346

→ returns: Upės · Ežerai · Vandens tyrimų vietos · Vandens matavimo stotys · Hidroelektrinės · Žuvų pralaidos · Žemių užtvankos · Vandens pertekliaus pralaidos · Upių pabaseiniai · Upių baseinai · Upių baseinų rajonai.

## Test plan
- [ ] Extract-PDF screenshot on staging shows the legend in the stakeholder's column order.
- [ ] Sidebar UETK layer toggle list order unchanged.
- [ ] uetk_public live map draw stack unchanged in both interactive and screenshot mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)