### PR TITLE
Gamtotvarkos žemėlapio pataisymai – Etapas 1 (#4, #2, #6)

### DIFF
--- a/src/components/features/accordion/Gamtotvarka.vue
+++ b/src/components/features/accordion/Gamtotvarka.vue
@@ -3,7 +3,8 @@
     <UiAccordionItem
       v-for="feature in features"
       :key="feature.featureId"
-      :title="getTitle(feature)"
+      :title="getTitleHtml(feature)"
+      @click="selectFeature(feature)"
     >
       <UiTable class="text-xs">
         <UiTableRow v-for="item in getSorted(feature)" :key="item.id">
@@ -21,6 +22,7 @@
 
 <script setup lang="ts">
 import { isInteger } from 'lodash';
+import { inject, onUnmounted } from 'vue';
 
 defineProps({
   features: {
@@ -29,16 +31,64 @@ defineProps({
   },
 });
 
-function getTitle(feature: any) {
-  const translates: any = {
-    tvarkymo_darbu_pateikimo_busena: 'Tvarkymo darbų pateikimo būsena',
-    tvarkymo_darbai: 'Atlikti tvarkymo darbai',
-  };
+const mapLayers: any = inject('mapLayers');
+const HIGHLIGHT_LAYER = 'gamtotvarkaHighlightLayer';
 
-  const objectType = translates[feature.featureId?.split('.')?.[0]];
+const translates: any = {
+  tvarkymo_darbai: 'Atlikti tvarkymo darbai',
+};
 
-  return `${objectType || feature._layerTitle}`;
+// Spalvų paletė kvadratėliams sąraše — spalva nustatoma pagal sluoksnį
+// (deterministiškai), kad skirtingų sluoksnių įrašai vizualiai skirtųsi (#6).
+const palette = ['#2e7d32', '#1565c0', '#6a1b9a', '#c62828', '#ef6c00', '#00838f'];
+
+function colorFor(feature: any) {
+  const key = String(feature._layerTitle || feature.featureId?.split('.')?.[0] || '');
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return palette[hash % palette.length];
 }
+
+function getTitle(feature: any) {
+  const objectType = translates[feature.featureId?.split('.')?.[0]];
+  return objectType || feature._layerTitle || '';
+}
+
+function getTitleHtml(feature: any) {
+  const color = colorFor(feature);
+  const square = `<span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:${color};margin-right:6px;vertical-align:middle;border:1px solid rgba(0,0,0,0.2)"></span>`;
+  return `${square}${getTitle(feature)}`;
+}
+
+// #6: pasirinkus įrašą — paryškinam būtent to ploto ribas atskirame sluoksnyje
+// ryškia spalva ir trumpai sumirksim, kad būtų aišku, kuris persidengiantis
+// plotas šiuo metu peržiūrimas. Veikia ir telefone (tap = click).
+let blinkTimer: any;
+
+function selectFeature(feature: any) {
+  if (!mapLayers || !feature?._geometry) return;
+
+  mapLayers.highlightFeatures(feature._geometry, { layer: HIGHLIGHT_LAYER });
+
+  const layer = mapLayers.getVectorLayer(HIGHLIGHT_LAYER);
+  if (!layer) return;
+
+  clearInterval(blinkTimer);
+  let count = 0;
+  layer.setVisible(true);
+  blinkTimer = setInterval(() => {
+    count++;
+    layer.setVisible(count % 2 === 0);
+    if (count >= 5) {
+      clearInterval(blinkTimer);
+      layer.setVisible(true);
+    }
+  }, 180);
+}
+
+onUnmounted(() => clearInterval(blinkTimer));
 
 const getSorted = (properties: any) => {
   return Object.entries(properties)
@@ -51,6 +101,6 @@ const getSorted = (properties: any) => {
       if (isInteger(a.id)) return a.id - b.id;
       return a.id.localeCompare(b.id);
     })
-    .filter((item: any) => !['featureId', '_layerTitle'].includes(item.name));
+    .filter((item: any) => !['featureId', '_layerTitle', '_geometry'].includes(item.name));
 };
 </script>

--- a/src/components/gamtotvarka/Filters.vue
+++ b/src/components/gamtotvarka/Filters.vue
@@ -1,36 +1,53 @@
 <template>
   <div class="flex justify-between items-center mb-2">
     <span class="text-sm font-semibold">Filtrai</span>
-    <UiButton type="link" @click="clearFilters"> Pradiniai filtrai </UiButton>
+    <UiButton type="link" @click="clearFilters"> Panaikinti filtrą </UiButton>
   </div>
-  <span class="text-sm mr-2"> Atliktų tvarkymo darbų metai: </span>
-  <input
-    v-model="selectedYear"
-    type="number"
-    class="border rounded p-1 text-sm w-24"
-    @change="applyDateFilter"
-  />
+  <span class="text-sm"> Atliktų tvarkymo darbų metai: </span>
+  <p class="text-xs text-gray-500 mb-2">Nepažymėjus metų, rodomi visų metų darbai.</p>
+  <div class="max-h-64 overflow-y-auto border rounded p-2 flex flex-col gap-1">
+    <label v-for="year in years" :key="year" class="flex items-center gap-2 text-sm cursor-pointer">
+      <input type="checkbox" :checked="selected.includes(year)" @change="toggleYear(year)" />
+      {{ year }}
+    </label>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
-const { selectedYear: initialSelectedYear } = defineProps({
-  selectedYear: {
-    type: Number,
-    default: 0,
+const props = defineProps({
+  selectedYears: {
+    type: Array,
+    default: () => [],
   },
 });
-const emit = defineEmits(['update:selectedYear']);
+const emit = defineEmits(['update:selectedYears']);
 
-const selectedYear = ref(initialSelectedYear);
+const selected = ref<number[]>([...(props.selectedYears as number[])]);
 
-const clearFilters = () => {
-  selectedYear.value = initialSelectedYear;
-  applyDateFilter();
+const years = computed(() => {
+  const max = new Date().getFullYear() + 1;
+  const list: number[] = [];
+  for (let y = max; y >= 2001; y--) list.push(y);
+  return list;
+});
+
+const apply = () => {
+  emit('update:selectedYears', [...selected.value]);
 };
 
-const applyDateFilter = () => {
-  emit('update:selectedYear', selectedYear.value);
+const toggleYear = (year: number) => {
+  if (selected.value.includes(year)) {
+    selected.value = selected.value.filter((y) => y !== year);
+  } else {
+    selected.value = [...selected.value, year].sort((a, b) => b - a);
+  }
+  apply();
+};
+
+const clearFilters = () => {
+  selected.value = [];
+  apply();
 };
 </script>

--- a/src/plugins/map.ts
+++ b/src/plugins/map.ts
@@ -9,9 +9,11 @@ import { watch } from 'vue';
 let map: Map;
 
 function getDiffKeys(obj1: any, obj2: any) {
-  return [...Object.keys(obj1 || {}), ...Object.keys(obj2 || {})]
+  const a = obj1 || {};
+  const b = obj2 || {};
+  return [...Object.keys(a), ...Object.keys(b)]
     .filter((value, index, array) => array.indexOf(value) === index)
-    .filter((key) => !_.isEqual(obj1[key], obj2[key]));
+    .filter((key) => !_.isEqual(a[key], b[key]));
 }
 
 export default {

--- a/src/routes/gamtotvarka.vue
+++ b/src/routes/gamtotvarka.vue
@@ -15,8 +15,8 @@
         <UiMapLayerToggle v-if="filtersStore.isActive('layers')" :layers="toggleLayers" />
         <GamtotvarkaFilters
           v-else-if="filtersStore.isActive('filters')"
-          :selected-year="selectedYear"
-          @update:selected-year="handleDateFilter"
+          :selected-years="selectedYears"
+          @update:selected-years="handleDateFilter"
         />
         <Search
           v-else-if="filtersStore.isActive('search')"
@@ -34,7 +34,7 @@
 </template>
 <script setup lang="ts">
 import Search from '@/components/search/Index.vue';
-import { inject, ref, computed } from 'vue';
+import { inject, ref } from 'vue';
 import { useFiltersStore } from '@/stores/filters';
 import GamtotvarkaFilters from '@/components/gamtotvarka/Filters.vue';
 import {
@@ -71,7 +71,6 @@ import {
   invaService,
 } from '@/utils';
 import { useRoute } from 'vue-router';
-import moment from 'moment';
 
 const eventBus: any = inject('eventBus');
 const filtersStore = useFiltersStore();
@@ -95,23 +94,31 @@ const toggleLayers = [
 ];
 
 const gamtotvarkaServiceFilters = mapLayers.filters(gamtotvarkaService.id);
-const gamtotvarkaPlanaiFilters = mapLayers.filters(gamtotvarkaPlanai.id);
 
-const filterByYear = (key: string, year: number) => {
-  const dateFrom = String(year);
-  const dateTo = String(year + 1);
-  gamtotvarkaServiceFilters.on(['tvarkymo_darbai']).set(key, {
-    $gte: dateFrom,
-    $lte: dateTo,
-  });
+// #2: pagal nutylėjimą rodomi visi atlikti darbai; galima filtruoti pagal kelis metus.
+// Tuščias metų sąrašas → nuimti „data“ filtrą (rodyti visus). Vienas metas →
+// vienas intervalas; keli metai → tų intervalų $or.
+const filterByYears = (years: number[]) => {
+  const filter = gamtotvarkaServiceFilters.on('tvarkymo_darbai');
+
+  if (!years.length) {
+    filter.remove('data');
+    return;
+  }
+
+  const ranges = years.map((year) => ({
+    $gte: String(year),
+    $lte: String(year + 1),
+  }));
+
+  filter.set('data', ranges.length === 1 ? ranges[0] : { $or: ranges });
 };
 
-const selectedYear = ref(parseInt(moment().startOf('year').format('YYYY')));
-filterByYear('data', selectedYear.value);
+const selectedYears = ref<number[]>([]);
 
-const handleDateFilter = (newDate: number) => {
-  selectedYear.value = newDate;
-  filterByYear('data', selectedYear.value);
+const handleDateFilter = (years: number[]) => {
+  selectedYears.value = years;
+  filterByYears(years);
 };
 
 mapLayers
@@ -131,11 +138,19 @@ mapLayers
   .click(async ({ coordinate }: any) => {
     selectedFeatures.value = [];
     eventBus.emit('uiSidebar', { open: false });
+    // #6: išvalom ankstesnį paryškinimą (bendrą ir aktyvaus ploto).
+    mapLayers.highlightFeatures(null);
+    mapLayers.highlightFeatures(null, { layer: 'gamtotvarkaHighlightLayer' });
     mapLayers.getFeatureInfo(
       gamtotvarkaService.id,
       coordinate,
       ({ geometries, properties }: any) => {
-        mapLayers.highlightFeatures(geometries);
+        // #6: kiekvienam įrašui prisegam jo geometriją (properties[i] ↔ geometries[i]),
+        // kad sąraše pasirinkus įrašą galėtume paryškinti būtent to ploto ribas.
+        properties.forEach((p: any, i: number) => {
+          p._geometry = geometries[i];
+        });
+        mapLayers.highlightFeatures(geometries, { merge: true });
         selectedFeatures.value.push(...properties);
         eventBus.emit('uiSidebar', { open: !!selectedFeatures.value.length });
       },
@@ -144,7 +159,12 @@ mapLayers
       gamtotvarkaNatura2000.id,
       coordinate,
       ({ geometries, properties }: any) => {
-        mapLayers.highlightFeatures(geometries);
+        // #6: kiekvienam įrašui prisegam jo geometriją (properties[i] ↔ geometries[i]),
+        // kad sąraše pasirinkus įrašą galėtume paryškinti būtent to ploto ribas.
+        properties.forEach((p: any, i: number) => {
+          p._geometry = geometries[i];
+        });
+        mapLayers.highlightFeatures(geometries, { merge: true });
         selectedFeatures.value.push(...properties);
         eventBus.emit('uiSidebar', { open: !!selectedFeatures.value.length });
       },
@@ -153,7 +173,12 @@ mapLayers
       gamtotvarkaStvkService.id,
       coordinate,
       ({ geometries, properties }: any) => {
-        mapLayers.highlightFeatures(geometries);
+        // #6: kiekvienam įrašui prisegam jo geometriją (properties[i] ↔ geometries[i]),
+        // kad sąraše pasirinkus įrašą galėtume paryškinti būtent to ploto ribas.
+        properties.forEach((p: any, i: number) => {
+          p._geometry = geometries[i];
+        });
+        mapLayers.highlightFeatures(geometries, { merge: true });
         selectedFeatures.value.push(...properties);
         eventBus.emit('uiSidebar', { open: !!selectedFeatures.value.length });
       },

--- a/src/utils/layers/theme.ts
+++ b/src/utils/layers/theme.ts
@@ -535,17 +535,13 @@ export const gamtotvarkaAtliktiDarbai = {
   title: 'Atlikti tvarkymo darbai',
   sublayers: [
     {
-      value: 'tvarkymo_darbu_pateikimo_busena',
-      name: 'Tvarkymo darbų pateikimo būsena',
-    },
-    {
       value: 'tvarkymo_darbai',
       name: 'Atlikti tvarkymo darbai',
     },
   ],
   layer: getWMSImageLayer(
     'https://wmsgisservice.biomon.lt/opengisservice/gamtotvarka',
-    'tvarkymo_darbai,tvarkymo_darbu_pateikimo_busena',
+    'tvarkymo_darbai',
     vsttCopyright,
   ),
 };

--- a/src/utils/layers/vector.ts
+++ b/src/utils/layers/vector.ts
@@ -171,6 +171,25 @@ export const fixedHighlightLayer = {
   }),
 };
 
+// Atskiras ryškus highlight sluoksnis gamtotvarkos žemėlapiui (#6): pasirinkus
+// įrašą sąraše, paryškina to ploto ribas kontrastine spalva (atskirai nuo
+// bendro highlightLayer, kuris žymi visus paspaustus persidengiančius plotus).
+const gamtotvarkaHighlightColor = '#ff6600';
+export const gamtotvarkaHighlightLayer = {
+  id: 'gamtotvarkaHighlightLayer',
+  layer: new VectorLayer({
+    style: new Style({
+      stroke: new Stroke({ color: gamtotvarkaHighlightColor, width: 4 }),
+      fill: new Fill({ color: 'rgba(255,102,0,0.15)' }),
+      image: new Circle({
+        radius: 9,
+        stroke: new Stroke({ color: gamtotvarkaHighlightColor, width: 4 }),
+        fill: new Fill({ color: 'rgba(255,102,0,0.3)' }),
+      }),
+    }),
+  }),
+};
+
 export const drawLayer = {
   id: 'drawLayer',
   layer: new VectorLayer({
@@ -259,6 +278,7 @@ export const vectorsLayer = {
       fixedHighlightLayer.layer,
       drawLayer.layer,
       highlightLayer.layer,
+      gamtotvarkaHighlightLayer.layer,
       markerLayer.layer,
       highlightLayerRusys.layer,
     ],


### PR DESCRIPTION
Etapas 1 iš [#223](https://github.com/AplinkosMinisterija/biip-maps-web/issues/223) (kilę iš [gamtotvarka-public#39](https://github.com/AplinkosMinisterija/biip-gamtotvarka-public/issues/39)). In-repo, be išorinių priklausomybių.

## #4 — Išimtas sluoksnis „Tvarkymo darbų pateikimo būsena"
`theme.ts` → `gamtotvarkaAtliktiDarbai`: pašalintas `tvarkymo_darbu_pateikimo_busena` iš `sublayers` ir WMS `LAYERS` (lieka tik `tvarkymo_darbai`); accordion `translates` išvalyti.

## #2 — Metų filtras: pagal nutylėjimą visi, multi-select, „Panaikinti filtrą"
- `Filters.vue`: vietoj vieno `number` lauko — checkbox sąrašas (2001 → kiti metai, naujausi viršuje). Nieko nepažymėta = rodomi **visi** atlikti darbai. Mygtukas „Panaikinti filtrą".
- `gamtotvarka.vue`: `filterByYear` → `filterByYears(years[])` (tuščia → `.remove('data')`; 1 metai → intervalas; keli → intervalų `$or` ant `tvarkymo_darbai`). Pašalintas auto-filtras pagal einamuosius metus užkrovus.

## #6 — Aktyvaus persidengiančio ploto pažymėjimas + spalvos kvadratėlis
- Naujas atskiras `gamtotvarkaHighlightLayer` (`vector.ts`, ryški kontrastinė spalva).
- `gamtotvarka.vue`: kiekvienam feature prisegama jo geometrija (`properties[i] ↔ geometries[i]`); paspaudus žemėlapį valomi seni paryškinimai.
- Accordion: spalvos kvadratėlis prie kiekvieno įrašo (pagal sluoksnį) + pasirinkus įrašą paryškinamos to ploto ribos su trumpu mirktelėjimu. Veikia ir telefone (touch). `_geometry` nerodoma savybių lentelėje.

## Patikra
- `vue-tsc --noEmit` ✅
- `eslint` ✅ (lint-staged pre-commit praėjo)
- Vizualus testas naršyklėje — atliekamas.

## Liko (kiti etapai, šiame PR ne)
- Etapas 2 (#3, #7) — laukia švaraus priemonės lauko iš biomon.
- Etapas 3 (#8) — papildomi servisai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)