### PR TITLE
feat(medziokle/edit): support hideUpload query param

### DIFF
--- a/src/routes/medziokle/edit.vue
+++ b/src/routes/medziokle/edit.vue
@@ -33,7 +33,7 @@
         </template>
 
         <UiButtonIcon icon="layers" @click="filtersStore.toggle('layers')" />
-        <UiButtonIcon icon="upload" @click="uploadRef?.modal?.open?.()" />
+        <UiButtonIcon v-if="!hideUpload" icon="upload" @click="uploadRef?.modal?.open?.()" />
       </template>
       <template v-if="filtersStore.active || showBufferChangeBox" #filtersContent>
         <UiMapLayerToggle v-if="filtersStore.isActive('layers')" :layers="toggleLayers" />
@@ -109,10 +109,12 @@ const query = parseRouteParams($route.query, [
   'bufferMax',
   'closeOnSearch',
   'showArea',
+  'hideUpload',
 ]);
 const isPreview = !!query.preview;
 const doHideToolbar = !!query.hideToolbar;
 const showArea = !!query.showArea;
+const hideUpload = !!query.hideUpload;
 
 const activeDrawType = computed(() => mapDraw.value.activeType);
 const selectedFeature = ref({} as any);


### PR DESCRIPTION
## Kontekstas

Žalos pranešimo forma (`biip-medziokle-public`) per šį žemėlapį leidžia **įkelti failą** (Shapefile/GeoJSON). Įkėlus daugiadalę geometriją (`MultiPolygon`) ar kelis objektus, `damages.createPublic` API ją atmeta (priima tik vieną `Point`/`Polygon`) ir vartotojas mato „Nepavyko išsaugoti anketos duomenų į duomenų bazę". Analizė: AplinkosMinisterija/biip-medziokle-public#85.

## Pakeitimas

Pridėtas `hideUpload` route parametras `medziokle/edit`, kuris paslepia failo įkėlimo mygtuką. Embedderiai gali jį įjungti (`?...&hideUpload=1`), kad vartotojas vietą galėtų nurodyti tik piešdamas.

```diff
  const query = parseRouteParams($route.query, [
    ... 'showArea',
+   'hideUpload',
  ]);

  const showArea = !!query.showArea;
+ const hideUpload = !!query.hideUpload;
```
```diff
- <UiButtonIcon icon="upload" @click="uploadRef?.modal?.open?.()" />
+ <UiButtonIcon v-if="!hideUpload" icon="upload" @click="uploadRef?.modal?.open?.()" />
```

Numatytasis elgesys nesikeičia (be parametro mygtukas rodomas kaip anksčiau) — atgaliniai suderinamumas išlaikytas.

## Susiję
- Naudoja šį parametrą: AplinkosMinisterija/biip-medziokle-public#86 (jau prideda `&hideUpload=1` prie iframe URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
